### PR TITLE
Nextjs example: load env from either `.env` or `.env.local`

### DIFF
--- a/examples/sdk/nextjs-delegated/.gitignore
+++ b/examples/sdk/nextjs-delegated/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/examples/sdk/nextjs-delegated/next.config.js
+++ b/examples/sdk/nextjs-delegated/next.config.js
@@ -1,7 +1,10 @@
-const result = require('dotenv').config({ path: '.env.local' })
+const dotenv = require('dotenv')
 
 const nextConfig = {
-  env: result.parsed,
+  env: {
+    ...dotenv.config({ path: '.env' }).parsed,
+    ...dotenv.config({ path: '.env.local' }).parsed,
+  },
   transpilePackages: ['@dfns/sdk-webauthn'],
 }
 

--- a/examples/sdk/nextjs-delegated/package-lock.json
+++ b/examples/sdk/nextjs-delegated/package-lock.json
@@ -33,15 +33,15 @@
     },
     "../../../packages/sdk": {
       "name": "@dfns/sdk",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "../../../packages/sdk-keysigner": {
       "name": "@dfns/sdk-keysigner",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "../../../packages/sdk-webauthn": {
       "name": "@dfns/sdk-webauthn",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",


### PR DESCRIPTION
In the nextjs-delegated-example, have dotenv load environment variables from either `.env` or `.env.local`, so that either one would be properly parsed (included multiline variables).