### PR TITLE
fix: switch auth client to newly generated client

### DIFF
--- a/examples/sdk/auth-delegated-key-credential/server/src/handlers/login.ts
+++ b/examples/sdk/auth-delegated-key-credential/server/src/handlers/login.ts
@@ -8,9 +8,7 @@ export const login = async (req: Request, res: Response) => {
   // end user to use WebAuthn or Passkeys to login.
   const username = req.body.username
   const client = apiClient(process.env.DFNS_APP_ID!)
-  const login = await client.auth.createDelegatedUserLogin({
-    body: { username },
-  })
+  const login = await client.auth.delegatedLogin({ body: { username } })
 
   // The auth token returned by delegated login should be cached securely for the
   // duration of the login session. It can be stored either on the server or on the

--- a/examples/sdk/auth-delegated-key-credential/server/src/handlers/register.ts
+++ b/examples/sdk/auth-delegated-key-credential/server/src/handlers/register.ts
@@ -14,7 +14,7 @@ export const registerInit = async (req: Request, res: Response) => {
   // otherwise the challenge returned does not have the appropriate relying
   // party and origin to create the WebAuthn or Passkeys credential
   const client = apiClient(appId)
-  const challenge = await client.auth.createDelegatedUserRegistration({
+  const challenge = await client.auth.createDelegatedRegistrationChallenge({
     body: { kind: UserAuthKind.EndUser, email: username },
   })
 

--- a/examples/sdk/auth-delegated/server/src/handlers/login.ts
+++ b/examples/sdk/auth-delegated/server/src/handlers/login.ts
@@ -8,9 +8,7 @@ export const login = async (req: Request, res: Response) => {
   // end user to use WebAuthn or Passkeys to login.
   const username = req.body.username
   const client = apiClient(process.env.DFNS_APP_ID!)
-  const login = await client.auth.createDelegatedUserLogin({
-    body: { username },
-  })
+  const login = await client.auth.delegatedLogin({ body: { username } })
 
   // The auth token returned by delegated login should be cached securely for the
   // duration of the login session. It can be stored either on the server or on the

--- a/examples/sdk/auth-delegated/server/src/handlers/register.ts
+++ b/examples/sdk/auth-delegated/server/src/handlers/register.ts
@@ -14,7 +14,7 @@ export const registerInit = async (req: Request, res: Response) => {
   // otherwise the challenge returned does not have the appropriate relying
   // party and origin to create the WebAuthn or Passkeys credential
   const client = apiClient(appId)
-  const challenge = await client.auth.createDelegatedUserRegistration({
+  const challenge = await client.auth.createDelegatedRegistrationChallenge({
     body: { kind: UserAuthKind.EndUser, email: username },
   })
 

--- a/examples/sdk/nextjs-delegated-recovery/app/api/login/route.ts
+++ b/examples/sdk/nextjs-delegated-recovery/app/api/login/route.ts
@@ -5,7 +5,7 @@ import { dfns } from '../utils'
 export async function POST(request: NextRequest) {
   const body = (await request.json()) as { email: string }
 
-  const { token: userAuthToken } = await dfns.auth.createDelegatedUserLogin({
+  const { token: userAuthToken } = await dfns.auth.delegatedLogin({
     body: { username: body.email },
   })
 

--- a/examples/sdk/nextjs-delegated-recovery/app/api/recover/complete/route.ts
+++ b/examples/sdk/nextjs-delegated-recovery/app/api/recover/complete/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: NextRequest) {
 
   // Complete end-user recovery
   const delegatedClient = await getDfnsDelegatedClient(body.tempAuthToken)
-  const result = await delegatedClient.auth.createUserRecovery({
+  const result = await delegatedClient.auth.recover({
     body: {
       newCredentials: body.newCredentials,
       recovery: body.signedRecoveryPackage,

--- a/examples/sdk/nextjs-delegated-recovery/app/api/recover/init/route.ts
+++ b/examples/sdk/nextjs-delegated-recovery/app/api/recover/init/route.ts
@@ -2,12 +2,12 @@ import { NextResponse } from 'next/server'
 import { dfns } from '../../utils'
 
 export async function POST(request: Request) {
-  const body = (await request.json()) as { username: string, credentialId: string }
+  const body = (await request.json()) as { username: string; credentialId: string }
 
   // Initiate end-user delegated recovery
-  const registrationChallenge = await dfns.auth.createDelegatedUserRecovery({
+  const recoveryChallenge = await dfns.auth.createDelegatedRecoveryChallenge({
     body: { username: body.username, credentialId: body.credentialId },
   })
 
-  return NextResponse.json(registrationChallenge)
+  return NextResponse.json(recoveryChallenge)
 }

--- a/examples/sdk/nextjs-delegated-recovery/app/api/register/complete/route.ts
+++ b/examples/sdk/nextjs-delegated-recovery/app/api/register/complete/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
   })
 
   // Perform delegated login to get the Dfns auth token of the end-user ("on his behalf")
-  const { token: userAuthToken } = await dfns.auth.createDelegatedUserLogin({
+  const { token: userAuthToken } = await dfns.auth.delegatedLogin({
     body: { username: result.user.username },
   })
 

--- a/examples/sdk/nextjs-delegated-recovery/app/api/register/init/route.ts
+++ b/examples/sdk/nextjs-delegated-recovery/app/api/register/init/route.ts
@@ -6,7 +6,7 @@ export async function POST(request: Request) {
   const body = (await request.json()) as { email: string }
 
   // Initiate end-user delegated registration
-  const registrationChallenge = await dfns.auth.createDelegatedUserRegistration({
+  const registrationChallenge = await dfns.auth.createDelegatedRegistrationChallenge({
     body: { email: body.email, kind: UserAuthKind.EndUser },
   })
 

--- a/examples/sdk/nextjs-delegated/README.md
+++ b/examples/sdk/nextjs-delegated/README.md
@@ -107,7 +107,7 @@ Delegated Login:
 
 ```ts
 // call delegated login to get the user auth token
-const { token: endUserAuthToken } = await dfns.auth.createDelegatedUserLogin({
+const { token: endUserAuthToken } = await dfns.auth.delegatedLogin({
   body: { username: body.email },
 })
 ```

--- a/examples/sdk/nextjs-delegated/app/api/login/route.ts
+++ b/examples/sdk/nextjs-delegated/app/api/login/route.ts
@@ -5,9 +5,7 @@ import { dfns } from '../utils'
 export async function POST(request: NextRequest) {
   const body = (await request.json()) as { email: string }
 
-  const { token: userAuthToken } = await dfns.auth.createDelegatedUserLogin({
-    body: { username: body.email },
-  })
+  const { token: userAuthToken } = await dfns.auth.delegatedLogin({ body: { username: body.email } })
 
   const response = NextResponse.json({ ok: true })
 

--- a/examples/sdk/nextjs-delegated/app/api/register/complete/route.ts
+++ b/examples/sdk/nextjs-delegated/app/api/register/complete/route.ts
@@ -20,29 +20,23 @@ export async function POST(request: NextRequest) {
   // saveUserDfnsInfo(result.user.id)
 
   // Create a generic permission to get/create wallets (can skip if permission was already created once)
-  const permission = (
-    await dfns.permissions.createPermission({
-      body: {
-        name: `Allow Wallet Create/Read - ${Date.now()}`,
-        operations: ['Wallets:Create', 'Wallets:Read'],
-      },
-    })
-  )
+  const permission = await dfns.permissions.createPermission({
+    body: {
+      name: `Allow Wallet Create/Read - ${Date.now()}`,
+      operations: ['Wallets:Create', 'Wallets:Read'],
+    },
+  })
 
   // Grant (assign) the permission to the end-user
-  const permissionAssignment = (
-    await dfns.permissions.createAssignment({
-      permissionId: permission.id,
-      body: {
-        identityId: result.user.id,
-      },
-    })
-  )
+  const permissionAssignment = await dfns.permissions.createAssignment({
+    permissionId: permission.id,
+    body: {
+      identityId: result.user.id,
+    },
+  })
 
   // Perform delegated login to get the Dfns auth token of the end-user ("on his behalf")
-  const { token: userAuthToken } = await dfns.auth.createDelegatedUserLogin({
-    body: { username: result.user.username },
-  })
+  const { token: userAuthToken } = await dfns.auth.delegatedLogin({ body: { username: result.user.username } })
 
   const response = NextResponse.json({ result, permission, permissionAssignment })
 

--- a/examples/sdk/nextjs-delegated/app/api/register/init/route.ts
+++ b/examples/sdk/nextjs-delegated/app/api/register/init/route.ts
@@ -6,7 +6,7 @@ export async function POST(request: Request) {
   const body = (await request.json()) as { email: string }
 
   // Initiate end-user delegated registration
-  const registrationChallenge = await dfns.auth.createDelegatedUserRegistration({
+  const registrationChallenge = await dfns.auth.createDelegatedRegistrationChallenge({
     body: { email: body.email, kind: UserAuthKind.EndUser },
   })
 

--- a/packages/sdk/baseAuthApi.ts
+++ b/packages/sdk/baseAuthApi.ts
@@ -15,9 +15,11 @@ import { HttpMethod, simpleFetch } from './utils/fetch'
 
 export type DfnsBaseApiOptions = {
   appId: string
-  appSecret?: string
+  /** Needs to be specified to use any endpoint that requires authentication */
   authToken?: string
-  baseUrl: string
+  /** Only needs to be specified when using another API environment */
+  baseUrl?: string
+  appSecret?: string
 }
 
 export type CreateUserActionChallengeRequest = {

--- a/packages/sdk/codegen/datamodel/Auth/types.ts
+++ b/packages/sdk/codegen/datamodel/Auth/types.ts
@@ -6,7 +6,9 @@ import {
   Username,
 } from '../Foundations'
 
-// FIXME: Missing documentation for Application
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type Application = {
   // FIXME: Missing documentation for appId
   appId: EntityId
@@ -15,13 +17,17 @@ export type Application = {
   apiToken?: Jwt
 }
 
-// FIXME: Missing documentation for GenericSuccessMessage
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type GenericSuccessMessage = {
   // FIXME: Missing documentation for message
   message: string
 }
 
-// FIXME: Missing documentation for UserRegistration
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserRegistration = {
   // FIXME: Missing documentation for credential
   credential: UserCredentialInformation
@@ -30,7 +36,9 @@ export type UserRegistration = {
   user: UserRegistrationInformation
 }
 
-// FIXME: Missing documentation for UserRegistrationChallenge
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserRegistrationChallenge = {
   // FIXME: Missing documentation for temporaryAuthenticationToken
   temporaryAuthenticationToken: Jwt
@@ -63,7 +71,9 @@ export type UserRegistrationChallenge = {
   excludeCredentials: AllowCredential[]
 }
 
-// FIXME: Missing documentation for UserLoginChallenge
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserLoginChallenge = {
   // FIXME: Missing documentation for supportedCredentialKinds
   supportedCredentialKinds: SupportedCredentials[]
@@ -90,19 +100,25 @@ export type UserLoginChallenge = {
   userVerification: AuthenticatorRequirementOptions
 }
 
-// FIXME: Missing documentation for UserLogin
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserLogin = {
   // FIXME: Missing documentation for token
   token: Jwt
 }
 
-// FIXME: Missing documentation for UserActionSignature
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserActionSignature = {
   // FIXME: Missing documentation for userAction
   userAction: string
 }
 
-// FIXME: Missing documentation for AccessTokenInfoWithPublicKey
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AccessTokenInfoWithPublicKey = {
   // FIXME: Missing documentation for accessToken
   accessToken?: Jwt
@@ -141,7 +157,9 @@ export type AccessTokenInfoWithPublicKey = {
   tokenId: EntityId
 }
 
-// FIXME: Missing documentation for UserInfo
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserInfo = {
   // FIXME: Missing documentation for username
   username: string
@@ -177,7 +195,9 @@ export type UserInfo = {
   permissionAssignments: PermissionAssignmentInfo[]
 }
 
-// FIXME: Missing documentation for UserAccessTokenInformation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserAccessTokenInformation = {
   // FIXME: Missing documentation for userInfo
   userInfo: UserInfo
@@ -186,7 +206,9 @@ export type UserAccessTokenInformation = {
   accessTokens: AccessTokenInfoWithPublicKey[]
 }
 
-// FIXME: Missing documentation for AppInfoWithPublicKey
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AppInfoWithPublicKey = {
   // FIXME: Missing documentation for appId
   appId: EntityId
@@ -216,7 +238,9 @@ export type AppInfoWithPublicKey = {
   accessTokens: AccessTokenInfoWithPublicKey[]
 }
 
-// FIXME: Missing documentation for CredentialInfo
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CredentialInfo = {
   // FIXME: Missing documentation for credentialId
   credentialId: string
@@ -246,7 +270,9 @@ export type CredentialInfo = {
   origin: string
 }
 
-// FIXME: Missing documentation for AvailableOrg
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AvailableOrg = {
   /**
    * The ID of the organization.
@@ -259,7 +285,9 @@ export type AvailableOrg = {
   appId: EntityId
 }
 
-// FIXME: Missing documentation for UserRecoveryChallenge
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserRecoveryChallenge = {
   // FIXME: Missing documentation for temporaryAuthenticationToken
   temporaryAuthenticationToken: Jwt
@@ -295,7 +323,9 @@ export type UserRecoveryChallenge = {
   allowedRecoveryCredentials: AllowRecoveryCredential[]
 }
 
-// FIXME: Missing documentation for UserRegistrationBase
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserRegistrationBase = {
   // FIXME: Missing documentation for temporaryAuthenticationToken
   temporaryAuthenticationToken: Jwt
@@ -307,7 +337,9 @@ export type UserRegistrationBase = {
   user: AuthenticationUserInformation
 }
 
-// FIXME: Missing documentation for Fido2Options
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type Fido2Options = {
   // FIXME: Missing documentation for temporaryAuthenticationToken
   temporaryAuthenticationToken: Jwt
@@ -347,7 +379,9 @@ export type Fido2Options = {
   pubKeyCredParams: PubKeyCredParams[]
 }
 
-// FIXME: Missing documentation for PublicKeyOptions
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type PublicKeyOptions = {
   // FIXME: Missing documentation for temporaryAuthenticationToken
   temporaryAuthenticationToken: Jwt
@@ -371,7 +405,9 @@ export type PublicKeyOptions = {
   attestation: AuthenticatorAttestationOptions
 }
 
-// FIXME: Missing documentation for AllowCredential
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AllowCredential = {
   /**
    * Must be 'public-key'
@@ -385,7 +421,9 @@ export type AllowCredential = {
   transports?: string
 }
 
-// FIXME: Missing documentation for RelyingParty
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RelyingParty = {
   // FIXME: Missing documentation for id
   id: string
@@ -394,7 +432,9 @@ export type RelyingParty = {
   name: string
 }
 
-// FIXME: Missing documentation for AuthenticationUserInformation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthenticationUserInformation = {
   // FIXME: Missing documentation for id
   id: EntityId
@@ -406,7 +446,9 @@ export type AuthenticationUserInformation = {
   name: string
 }
 
-// FIXME: Missing documentation for PubKeyCredParams
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type PubKeyCredParams = {
   /**
    * Must be 'public-key'
@@ -417,7 +459,9 @@ export type PubKeyCredParams = {
   alg: number
 }
 
-// FIXME: Missing documentation for AuthenticatorSelection
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthenticatorSelection = {
   /**
    * If not given, any authenticator type can be used.
@@ -451,7 +495,9 @@ export type AuthenticatorSelection = {
   userVerification: AuthenticatorRequirementOptions
 }
 
-// FIXME: Missing documentation for ExcludeCredentials
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type ExcludeCredentials = {
   /**
    * Must be 'public-key'
@@ -465,7 +511,9 @@ export type ExcludeCredentials = {
   transports: FidoCredentialsTransportKind
 }
 
-// FIXME: Missing documentation for UserCredentialInformation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserCredentialInformation = {
   // FIXME: Missing documentation for uuid
   uuid: EntityId
@@ -477,7 +525,9 @@ export type UserCredentialInformation = {
   name: string
 }
 
-// FIXME: Missing documentation for UserRegistrationInformation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserRegistrationInformation = {
   // FIXME: Missing documentation for id
   id: EntityId
@@ -489,7 +539,9 @@ export type UserRegistrationInformation = {
   orgId: EntityId
 }
 
-// FIXME: Missing documentation for AuthenticateUserPasswordInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthenticateUserPasswordInput = {
   // FIXME: Missing documentation for kind
   kind: CredentialKind.Password
@@ -498,7 +550,9 @@ export type AuthenticateUserPasswordInput = {
   password: string
 }
 
-// FIXME: Missing documentation for AuthenticateUserFido2Input
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthenticateUserFido2Input = {
   // FIXME: Missing documentation for kind
   kind: CredentialKind.Fido2
@@ -507,7 +561,9 @@ export type AuthenticateUserFido2Input = {
   credentialAssertion: Fido2CredentialAssertion
 }
 
-// FIXME: Missing documentation for Fido2CredentialAssertion
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type Fido2CredentialAssertion = {
   // FIXME: Missing documentation for credId
   credId: string
@@ -525,7 +581,9 @@ export type Fido2CredentialAssertion = {
   userHandle: string
 }
 
-// FIXME: Missing documentation for KeyCredentialAssertion
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type KeyCredentialAssertion = {
   // FIXME: Missing documentation for credId
   credId: string
@@ -540,7 +598,9 @@ export type KeyCredentialAssertion = {
   algorithm?: string
 }
 
-// FIXME: Missing documentation for AuthenticateUserKeyInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthenticateUserKeyInput = {
   // FIXME: Missing documentation for kind
   kind: CredentialKind.Key
@@ -549,7 +609,9 @@ export type AuthenticateUserKeyInput = {
   credentialAssertion: KeyCredentialAssertion
 }
 
-// FIXME: Missing documentation for SupportedCredentialKinds
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type SupportedCredentialKinds = {
   // FIXME: Missing documentation for firstFactor
   firstFactor: CredentialKind[]
@@ -558,7 +620,9 @@ export type SupportedCredentialKinds = {
   secondFactor: CredentialKind[]
 }
 
-// FIXME: Missing documentation for RegistrationConfirmationFido2
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RegistrationConfirmationFido2 = {
   // FIXME: Missing documentation for credentialKind
   credentialKind: CredentialKind.Fido2
@@ -567,7 +631,9 @@ export type RegistrationConfirmationFido2 = {
   credentialInfo: CredentialAssertion
 }
 
-// FIXME: Missing documentation for RegistrationConfirmationKey
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RegistrationConfirmationKey = {
   // FIXME: Missing documentation for credentialKind
   credentialKind: CredentialKind.Key
@@ -576,7 +642,9 @@ export type RegistrationConfirmationKey = {
   credentialInfo: CredentialAssertion
 }
 
-// FIXME: Missing documentation for RegistrationConfirmationRecoveryKey
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RegistrationConfirmationRecoveryKey = {
   // FIXME: Missing documentation for encryptedPrivateKey
   encryptedPrivateKey?: string
@@ -588,7 +656,9 @@ export type RegistrationConfirmationRecoveryKey = {
   credentialKind: CredentialKind.RecoveryKey
 }
 
-// FIXME: Missing documentation for CredentialAssertion
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CredentialAssertion = {
   // FIXME: Missing documentation for credId
   credId: string
@@ -600,7 +670,9 @@ export type CredentialAssertion = {
   attestationData: string
 }
 
-// FIXME: Missing documentation for RegistrationConfirmationPassword
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RegistrationConfirmationPassword = {
   // FIXME: Missing documentation for credentialKind
   credentialKind: CredentialKind.Password
@@ -609,13 +681,17 @@ export type RegistrationConfirmationPassword = {
   credentialInfo: PasswordCredentialInformation
 }
 
-// FIXME: Missing documentation for PasswordCredentialInformation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type PasswordCredentialInformation = {
   // FIXME: Missing documentation for password
   password: string
 }
 
-// FIXME: Missing documentation for RegistrationConfirmationTotp
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RegistrationConfirmationTotp = {
   // FIXME: Missing documentation for credentialKind
   credentialKind: CredentialKind.Totp
@@ -624,13 +700,17 @@ export type RegistrationConfirmationTotp = {
   credentialInfo: TotpCredentialInformation
 }
 
-// FIXME: Missing documentation for TotpCredentialInformation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type TotpCredentialInformation = {
   // FIXME: Missing documentation for otpCode
   otpCode: string
 }
 
-// FIXME: Missing documentation for AllowCredentials
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AllowCredentials = {
   // FIXME: Missing documentation for webauthn
   webauthn: AllowCredential[]
@@ -639,7 +719,9 @@ export type AllowCredentials = {
   key: AllowCredential[]
 }
 
-// FIXME: Missing documentation for SupportedCredentials
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type SupportedCredentials = {
   // FIXME: Missing documentation for kind
   kind: CredentialKind
@@ -651,7 +733,9 @@ export type SupportedCredentials = {
   requiresSecondFactor: boolean
 }
 
-// FIXME: Missing documentation for AuthenticateUserTotpInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthenticateUserTotpInput = {
   // FIXME: Missing documentation for kind
   kind: CredentialKind.Totp
@@ -660,7 +744,9 @@ export type AuthenticateUserTotpInput = {
   otpCode: string
 }
 
-// FIXME: Missing documentation for TotpCredential
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type TotpCredential = {
   // FIXME: Missing documentation for temporaryAuthenticationToken
   temporaryAuthenticationToken: Jwt
@@ -678,7 +764,9 @@ export type TotpCredential = {
   otpUrl: string
 }
 
-// FIXME: Missing documentation for PasswordCredential
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type PasswordCredential = {
   // FIXME: Missing documentation for temporaryAuthenticationToken
   temporaryAuthenticationToken: Jwt
@@ -693,7 +781,9 @@ export type PasswordCredential = {
   kind: CredentialKind.Password
 }
 
-// FIXME: Missing documentation for CreateUserCredentialInputBase
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserCredentialInputBase = {
   // FIXME: Missing documentation for challengeIdentifier
   challengeIdentifier: Jwt
@@ -702,7 +792,9 @@ export type CreateUserCredentialInputBase = {
   credentialName: string
 }
 
-// FIXME: Missing documentation for CreateUserCredentialTotpInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserCredentialTotpInput = {
   // FIXME: Missing documentation for challengeIdentifier
   challengeIdentifier: Jwt
@@ -717,7 +809,9 @@ export type CreateUserCredentialTotpInput = {
   credentialInfo: TotpCredentialInformation
 }
 
-// FIXME: Missing documentation for CreateUserCredentialPasswordInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserCredentialPasswordInput = {
   // FIXME: Missing documentation for credentialKind
   credentialKind: CredentialKind.Password
@@ -732,7 +826,9 @@ export type CreateUserCredentialPasswordInput = {
   credentialName: string
 }
 
-// FIXME: Missing documentation for CreateUserCredentialPublicKeyInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserCredentialPublicKeyInput = {
   // FIXME: Missing documentation for challengeIdentifier
   challengeIdentifier: Jwt
@@ -747,7 +843,9 @@ export type CreateUserCredentialPublicKeyInput = {
   credentialInfo: CredentialAssertion
 }
 
-// FIXME: Missing documentation for CreateUserCredentialFido2Input
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserCredentialFido2Input = {
   // FIXME: Missing documentation for credentialKind
   credentialKind: CredentialKind.Fido2
@@ -762,7 +860,9 @@ export type CreateUserCredentialFido2Input = {
   credentialName: string
 }
 
-// FIXME: Missing documentation for HttpRequestInformation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type HttpRequestInformation = {
   // FIXME: Missing documentation for method
   method: string
@@ -777,7 +877,9 @@ export type HttpRequestInformation = {
   path: string
 }
 
-// FIXME: Missing documentation for LegacyAuthAttestation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type LegacyAuthAttestation = {
   // FIXME: Missing documentation for token
   token: Jwt
@@ -789,7 +891,9 @@ export type LegacyAuthAttestation = {
   authIdentity: AuthIdentity
 }
 
-// FIXME: Missing documentation for OrgEmployeeIdentity
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type OrgEmployeeIdentity = {
   // FIXME: Missing documentation for kind
   kind: AuthIdentityKind.OrgEmployeeIdentity
@@ -810,7 +914,9 @@ export type OrgEmployeeIdentity = {
   permissions: string[]
 }
 
-// FIXME: Missing documentation for OrgApiKeyIdentity
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type OrgApiKeyIdentity = {
   // FIXME: Missing documentation for kind
   kind: AuthIdentityKind.OrgApiKeyIdentity
@@ -828,7 +934,9 @@ export type OrgApiKeyIdentity = {
   permissions: string[]
 }
 
-// FIXME: Missing documentation for DfnsStaffIdentity
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type DfnsStaffIdentity = {
   // FIXME: Missing documentation for kind
   kind: AuthIdentityKind.DfnsStaffIdentity
@@ -849,7 +957,9 @@ export type DfnsStaffIdentity = {
   permissions: string[]
 }
 
-// FIXME: Missing documentation for DfnsServiceIdentity
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type DfnsServiceIdentity = {
   // FIXME: Missing documentation for kind
   kind: AuthIdentityKind.DfnsService
@@ -858,13 +968,17 @@ export type DfnsServiceIdentity = {
   serviceName: string
 }
 
-// FIXME: Missing documentation for AuthV2SignedAuthAttestation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthV2SignedAuthAttestation = {
   // FIXME: Missing documentation for authBlock
   authBlock: AuthBlock
 }
 
-// FIXME: Missing documentation for JwtHeader
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type JwtHeader = {
   // FIXME: Missing documentation for alg
   alg?: string
@@ -879,7 +993,9 @@ export type JwtHeader = {
   typ?: string
 }
 
-// FIXME: Missing documentation for DecodedJwt
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type DecodedJwt = {
   // FIXME: Missing documentation for payload
   payload: JwtPayload
@@ -888,7 +1004,9 @@ export type DecodedJwt = {
   header: JwtHeader
 }
 
-// FIXME: Missing documentation for AuthBlock
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthBlock = {
   // FIXME: Missing documentation for request
   request: Jwt
@@ -897,7 +1015,9 @@ export type AuthBlock = {
   auth: Jwt
 }
 
-// FIXME: Missing documentation for CreateUserCredentialRecoveryKeyInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserCredentialRecoveryKeyInput = {
   // FIXME: Missing documentation for encryptedPrivateKey
   encryptedPrivateKey?: string
@@ -915,7 +1035,9 @@ export type CreateUserCredentialRecoveryKeyInput = {
   credentialName: string
 }
 
-// FIXME: Missing documentation for PermissionAssignmentInfo
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type PermissionAssignmentInfo = {
   // FIXME: Missing documentation for permissionName
   permissionName: string
@@ -930,7 +1052,9 @@ export type PermissionAssignmentInfo = {
   operations?: string[]
 }
 
-// FIXME: Missing documentation for AllowRecoveryCredential
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AllowRecoveryCredential = {
   // FIXME: Missing documentation for id
   id: string
@@ -939,7 +1063,9 @@ export type AllowRecoveryCredential = {
   encryptedRecoveryKey: string
 }
 
-// FIXME: Missing documentation for RecoverUserInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RecoverUserInput = {
   // FIXME: Missing documentation for kind
   kind: CredentialKind.RecoveryKey
@@ -948,7 +1074,9 @@ export type RecoverUserInput = {
   credentialAssertion: KeyCredentialAssertion
 }
 
-// FIXME: Missing documentation for UserRecoveryCredentials
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserRecoveryCredentials = {
   // FIXME: Missing documentation for firstFactorCredential
   firstFactorCredential: RegistrationFirstFactor
@@ -966,7 +1094,9 @@ export type Jwt = string
 // FIXME: Missing documentation for JwtPayload
 export type JwtPayload = Record<string, unknown>
 
-// FIXME: Missing documentation for CreateUserActionSignatureChallengeInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserActionSignatureChallengeInput = {
   /**
    * Human readable explanation of the activity, so that person can understand what is being signed.
@@ -983,13 +1113,17 @@ export type CreateUserActionSignatureChallengeInput = {
   userActionServerKind?: ServerKind
 }
 
-// FIXME: Missing documentation for CreateDelegatedUserLoginInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateDelegatedUserLoginInput = {
   // FIXME: Missing documentation for username
   username: string
 }
 
-// FIXME: Missing documentation for CreateUserInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserInput = {
   // FIXME: Missing documentation for email
   email: string
@@ -1004,7 +1138,9 @@ export type CreateUserInput = {
   externalId?: string
 }
 
-// FIXME: Missing documentation for CreateUserRegistrationChallengeInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserRegistrationChallengeInput = {
   // FIXME: Missing documentation for username
   username: string
@@ -1016,7 +1152,9 @@ export type CreateUserRegistrationChallengeInput = {
   orgId: EntityId
 }
 
-// FIXME: Missing documentation for CreateUserRegistrationInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserRegistrationInput = {
   // FIXME: Missing documentation for firstFactorCredential
   firstFactorCredential: RegistrationFirstFactor
@@ -1028,7 +1166,9 @@ export type CreateUserRegistrationInput = {
   recoveryCredential?: RegistrationConfirmationRecoveryKey
 }
 
-// FIXME: Missing documentation for CreateUserLoginChallengeInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserLoginChallengeInput = {
   // FIXME: Missing documentation for username
   username: string
@@ -1037,7 +1177,9 @@ export type CreateUserLoginChallengeInput = {
   orgId: EntityId
 }
 
-// FIXME: Missing documentation for CreateUserLoginInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserLoginInput = {
   // FIXME: Missing documentation for challengeIdentifier
   challengeIdentifier: Jwt
@@ -1049,19 +1191,25 @@ export type CreateUserLoginInput = {
   secondFactor?: AuthenticateUserSecondFactor
 }
 
-// FIXME: Missing documentation for CreateUserCredentialChallengeInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserCredentialChallengeInput = {
   // FIXME: Missing documentation for kind
   kind: CredentialKind
 }
 
-// FIXME: Missing documentation for ActivateCredentialInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type ActivateCredentialInput = {
   // FIXME: Missing documentation for credentialUuid
   credentialUuid: EntityId
 }
 
-// FIXME: Missing documentation for CreateSignedAuthAttestationInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateSignedAuthAttestationInput = {
   // FIXME: Missing documentation for body
   body?: string
@@ -1076,19 +1224,25 @@ export type CreateSignedAuthAttestationInput = {
   http: HttpRequestInformation
 }
 
-// FIXME: Missing documentation for CreateCodeLoginChallengeInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateCodeLoginChallengeInput = {
   // FIXME: Missing documentation for code
   code: string
 }
 
-// FIXME: Missing documentation for CreateUserLoginFromCodeInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserLoginFromCodeInput = {
   // FIXME: Missing documentation for challengeIdentifier
   challengeIdentifier: Jwt
 }
 
-// FIXME: Missing documentation for CreateOrgOwnerInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateOrgOwnerInput = {
   // FIXME: Missing documentation for email
   email: Email
@@ -1103,7 +1257,9 @@ export type CreateOrgOwnerInput = {
   authBlock: AuthBlock
 }
 
-// FIXME: Missing documentation for CreateAvailableOrgListInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateAvailableOrgListInput = {
   /**
    * The username of the user that is logging into the system.
@@ -1132,7 +1288,9 @@ export type CreateAvailableOrgListInput = {
   origin: string
 }
 
-// FIXME: Missing documentation for CreateAccessTokenInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateAccessTokenInput = {
   // FIXME: Missing documentation for daysValid
   daysValid?: IntegerPositiveStrict
@@ -1150,7 +1308,9 @@ export type CreateAccessTokenInput = {
   externalId?: string
 }
 
-// FIXME: Missing documentation for UpdateAccessTokenInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UpdateAccessTokenInput = {
   // FIXME: Missing documentation for name
   name?: string
@@ -1159,7 +1319,9 @@ export type UpdateAccessTokenInput = {
   externalId?: string
 }
 
-// FIXME: Missing documentation for UpdateUserInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UpdateUserInput = {
   // FIXME: Missing documentation for externalId
   externalId?: string
@@ -1168,7 +1330,9 @@ export type UpdateUserInput = {
   publicKey?: string
 }
 
-// FIXME: Missing documentation for UpdateApplicationInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UpdateApplicationInput = {
   // FIXME: Missing documentation for externalId
   externalId?: string
@@ -1177,7 +1341,9 @@ export type UpdateApplicationInput = {
   name?: string
 }
 
-// FIXME: Missing documentation for CreateApplicationInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateApplicationInput = {
   // FIXME: Missing documentation for name
   name: string
@@ -1204,7 +1370,9 @@ export type CreateApplicationInput = {
   externalId?: string
 }
 
-// FIXME: Missing documentation for CreateUserRecoveryInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserRecoveryInput = {
   // FIXME: Missing documentation for recovery
   recovery: RecoverUserInput
@@ -1213,7 +1381,9 @@ export type CreateUserRecoveryInput = {
   newCredentials: UserRecoveryCredentials
 }
 
-// FIXME: Missing documentation for CreateUserRecoveryChallengeInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserRecoveryChallengeInput = {
   // FIXME: Missing documentation for username
   username: string
@@ -1228,7 +1398,9 @@ export type CreateUserRecoveryChallengeInput = {
   credentialId: string
 }
 
-// FIXME: Missing documentation for CreateDelegatedUserRecoveryInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateDelegatedUserRecoveryInput = {
   // FIXME: Missing documentation for username
   username: string
@@ -1237,7 +1409,9 @@ export type CreateDelegatedUserRecoveryInput = {
   credentialId: string
 }
 
-// FIXME: Missing documentation for CreateUserCredentialInput
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type CreateUserCredentialInput =
   | CreateUserCredentialTotpInput
   | CreateUserCredentialPasswordInput
@@ -1245,50 +1419,66 @@ export type CreateUserCredentialInput =
   | CreateUserCredentialFido2Input
   | CreateUserCredentialRecoveryKeyInput
 
-// FIXME: Missing documentation for UserCredentialChallenge
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type UserCredentialChallenge =
   | Fido2Options
   | PublicKeyOptions
   | TotpCredential
   | PasswordCredential
 
-// FIXME: Missing documentation for SignedAuthAttestation
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type SignedAuthAttestation =
   | LegacyAuthAttestation
   | AuthV2SignedAuthAttestation
 
-// FIXME: Missing documentation for RegistrationFirstFactor
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RegistrationFirstFactor =
   | RegistrationConfirmationFido2
   | RegistrationConfirmationKey
   | RegistrationConfirmationPassword
 
-// FIXME: Missing documentation for RegistrationSecondFactor
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type RegistrationSecondFactor =
   | RegistrationConfirmationFido2
   | RegistrationConfirmationKey
   | RegistrationConfirmationTotp
 
-// FIXME: Missing documentation for AuthenticateUserFirstFactor
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthenticateUserFirstFactor =
   | AuthenticateUserPasswordInput
   | AuthenticateUserFido2Input
   | AuthenticateUserKeyInput
 
-// FIXME: Missing documentation for AuthenticateUserSecondFactor
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthenticateUserSecondFactor =
   | AuthenticateUserFido2Input
   | AuthenticateUserKeyInput
   | AuthenticateUserTotpInput
 
-// FIXME: Missing documentation for AuthIdentity
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export type AuthIdentity =
   | OrgEmployeeIdentity
   | OrgApiKeyIdentity
   | DfnsStaffIdentity
   | DfnsServiceIdentity
 
-// FIXME: Missing documentation for CredentialKind
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum CredentialKind {
   // FIXME: Missing documentation for Fido2
   Fido2 = 'Fido2',
@@ -1302,7 +1492,9 @@ export enum CredentialKind {
   RecoveryKey = 'RecoveryKey',
 }
 
-// FIXME: Missing documentation for UserKind
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum UserKind {
   // FIXME: Missing documentation for CustomerEmployee
   CustomerEmployee = 'CustomerEmployee',
@@ -1318,7 +1510,9 @@ export enum UserKind {
   ServiceAccount = 'ServiceAccount',
 }
 
-// FIXME: Missing documentation for AuthenticatorRequirementOptions
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum AuthenticatorRequirementOptions {
   // FIXME: Missing documentation for required
   required = 'required',
@@ -1328,7 +1522,9 @@ export enum AuthenticatorRequirementOptions {
   discouraged = 'discouraged',
 }
 
-// FIXME: Missing documentation for AuthenticatorAttestationOptions
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum AuthenticatorAttestationOptions {
   // FIXME: Missing documentation for none
   none = 'none',
@@ -1340,7 +1536,9 @@ export enum AuthenticatorAttestationOptions {
   enterprise = 'enterprise',
 }
 
-// FIXME: Missing documentation for ApplicationKind
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum ApplicationKind {
   // FIXME: Missing documentation for ServerSideApplication
   ServerSideApplication = 'ServerSideApplication',
@@ -1348,7 +1546,9 @@ export enum ApplicationKind {
   ClientSideApplication = 'ClientSideApplication',
 }
 
-// FIXME: Missing documentation for FidoCredentialsTransportKind
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum FidoCredentialsTransportKind {
   // FIXME: Missing documentation for usb
   usb = 'usb',
@@ -1362,7 +1562,9 @@ export enum FidoCredentialsTransportKind {
   hybrid = 'hybrid',
 }
 
-// FIXME: Missing documentation for CredentialFactor
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum CredentialFactor {
   // FIXME: Missing documentation for first
   first = 'first',
@@ -1372,7 +1574,9 @@ export enum CredentialFactor {
   either = 'either',
 }
 
-// FIXME: Missing documentation for ServerKind
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum ServerKind {
   // FIXME: Missing documentation for Api
   Api = 'Api',
@@ -1380,7 +1584,9 @@ export enum ServerKind {
   Staff = 'Staff',
 }
 
-// FIXME: Missing documentation for AccessTokenKind
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum AccessTokenKind {
   // FIXME: Missing documentation for ServiceAccount
   ServiceAccount = 'ServiceAccount',
@@ -1390,7 +1596,9 @@ export enum AccessTokenKind {
   Application = 'Application',
 }
 
-// FIXME: Missing documentation for UserAuthKind
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum UserAuthKind {
   // FIXME: Missing documentation for EndUser
   EndUser = 'EndUser',
@@ -1400,7 +1608,9 @@ export enum UserAuthKind {
   DfnsStaff = 'DfnsStaff',
 }
 
-// FIXME: Missing documentation for AuthIdentityKind
+/**
+ * @deprecated import equivalent type from '@dfns/sdk/types/auth' instead
+ */
 export enum AuthIdentityKind {
   // FIXME: Missing documentation for DfnsStaffIdentity
   DfnsStaffIdentity = 'DfnsStaffIdentity',

--- a/packages/sdk/dfnsApiClient.ts
+++ b/packages/sdk/dfnsApiClient.ts
@@ -12,7 +12,8 @@ import { WebhooksClient } from './generated/webhooks'
 import { CredentialSigner } from './signer'
 
 export type DfnsApiClientOptions = DfnsBaseApiOptions & {
-  signer: CredentialSigner
+  /** Needs to be specified to use any endpoint that required User Action Signing flow */
+  signer?: CredentialSigner
 }
 
 export class DfnsApiClient {

--- a/packages/sdk/dfnsApiClient.ts
+++ b/packages/sdk/dfnsApiClient.ts
@@ -1,6 +1,6 @@
 import { DfnsBaseApiOptions } from './baseAuthApi'
 import { AssetsClient } from './codegen/Assets'
-import { AuthClient } from './codegen/Auth'
+import { AuthClient } from './generated/auth'
 import { CallbacksClient } from './codegen/Callbacks'
 import { PublicKeysClient } from './codegen/PublicKeys'
 import { NetworksClient } from './generated/networks'

--- a/packages/sdk/dfnsDelegatedApiClient.ts
+++ b/packages/sdk/dfnsDelegatedApiClient.ts
@@ -1,6 +1,6 @@
 import { DfnsBaseApiOptions } from './baseAuthApi'
 import { DelegatedAssetsClient } from './codegen/Assets'
-import { DelegatedAuthClient } from './codegen/Auth'
+import { DelegatedAuthClient } from './generated/auth'
 import { DelegatedCallbacksClient } from './codegen/Callbacks'
 import { DelegatedPublicKeysClient } from './codegen/PublicKeys'
 import { DelegatedNetworksClient } from './generated/networks'

--- a/packages/sdk/dfnsDelegatedApiClient.ts
+++ b/packages/sdk/dfnsDelegatedApiClient.ts
@@ -10,9 +10,7 @@ import { DelegatedSignersClient } from './generated/signers'
 import { DelegatedWalletsClient } from './generated/wallets'
 import { DelegatedWebhooksClient } from './generated/webhooks'
 
-export type DfnsDelegatedApiClientOptions = DfnsBaseApiOptions & {
-  authToken: string
-}
+export type DfnsDelegatedApiClientOptions = DfnsBaseApiOptions
 
 export class DfnsDelegatedApiClient {
   constructor(private apiOptions: DfnsDelegatedApiClientOptions) {}

--- a/packages/sdk/generated/auth/client.ts
+++ b/packages/sdk/generated/auth/client.ts
@@ -1,0 +1,828 @@
+import { DfnsApiClientOptions } from '../../dfnsApiClient'
+import { simpleFetch, userActionFetch } from '../../utils/fetch'
+import { buildPathAndQuery } from '../../utils/url'
+import * as T from './types'
+
+export class AuthClient {
+  constructor(private apiOptions: DfnsApiClientOptions) {}
+
+  async activateApplication(request: T.ActivateApplicationRequest): Promise<T.ActivateApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async activateCredential(request: T.ActivateCredentialRequest): Promise<T.ActivateCredentialResponse> {
+    const path = buildPathAndQuery('/auth/credentials/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async activatePersonalAccessToken(request: T.ActivatePersonalAccessTokenRequest): Promise<T.ActivatePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async activateServiceAccount(request: T.ActivateServiceAccountRequest): Promise<T.ActivateServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async activateUser(request: T.ActivateUserRequest): Promise<T.ActivateUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async archiveApplication(request: T.ArchiveApplicationRequest): Promise<T.ArchiveApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'DELETE',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async archivePersonalAccessToken(request: T.ArchivePersonalAccessTokenRequest): Promise<T.ArchivePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'DELETE',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async archiveServiceAccount(request: T.ArchiveServiceAccountRequest): Promise<T.ArchiveServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'DELETE',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async archiveUser(request: T.ArchiveUserRequest): Promise<T.ArchiveUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'DELETE',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createApplication(request: T.CreateApplicationRequest): Promise<T.CreateApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createCredential(request: T.CreateCredentialRequest): Promise<T.CreateCredentialResponse> {
+    const path = buildPathAndQuery('/auth/credentials', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use createCredential instead */
+  async createUserCredential(request: T.CreateCredentialRequest): Promise<T.CreateCredentialResponse> {
+    return this.createCredential(request)
+  }
+
+  async createCredentialChallenge(request: T.CreateCredentialChallengeRequest): Promise<T.CreateCredentialChallengeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use createCredentialChallenge instead */
+  async createUserCredentialChallenge(request: T.CreateCredentialChallengeRequest): Promise<T.CreateCredentialChallengeResponse> {
+    return this.createCredentialChallenge(request)
+  }
+
+  async createCredentialChallengeWithCode(request: T.CreateCredentialChallengeWithCodeRequest): Promise<T.CreateCredentialChallengeWithCodeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/code/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createCredentialCode(request: T.CreateCredentialCodeRequest): Promise<T.CreateCredentialCodeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/code', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createCredentialWithCode(request: T.CreateCredentialWithCodeRequest): Promise<T.CreateCredentialWithCodeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/code/verify', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createDelegatedRecoveryChallenge(request: T.CreateDelegatedRecoveryChallengeRequest): Promise<T.CreateDelegatedRecoveryChallengeResponse> {
+    const path = buildPathAndQuery('/auth/recover/user/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use createDelegatedRecoveryChallenge instead */
+  async createDelegatedUserRecovery(request: T.CreateDelegatedRecoveryChallengeRequest): Promise<T.CreateDelegatedRecoveryChallengeResponse> {
+    return this.createDelegatedRecoveryChallenge(request)
+  }
+
+  async createDelegatedRegistrationChallenge(request: T.CreateDelegatedRegistrationChallengeRequest): Promise<T.CreateDelegatedRegistrationChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use createDelegatedRegistrationChallenge instead */
+  async createDelegatedUserRegistration(request: T.CreateDelegatedRegistrationChallengeRequest): Promise<T.CreateDelegatedRegistrationChallengeResponse> {
+    return this.createDelegatedRegistrationChallenge(request)
+  }
+
+  async createLoginChallenge(request: T.CreateLoginChallengeRequest): Promise<T.CreateLoginChallengeResponse> {
+    const path = buildPathAndQuery('/auth/login/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createPersonalAccessToken(request: T.CreatePersonalAccessTokenRequest): Promise<T.CreatePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createRecoveryChallenge(request: T.CreateRecoveryChallengeRequest): Promise<T.CreateRecoveryChallengeResponse> {
+    const path = buildPathAndQuery('/auth/recover/user/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createRegistrationChallenge(request: T.CreateRegistrationChallengeRequest): Promise<T.CreateRegistrationChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createServiceAccount(request: T.CreateServiceAccountRequest): Promise<T.CreateServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createUser(request: T.CreateUserRequest): Promise<T.CreateUserResponse> {
+    const path = buildPathAndQuery('/auth/users', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createUserActionChallenge(request: T.CreateUserActionChallengeRequest): Promise<T.CreateUserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/action/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use createUserActionChallenge instead */
+  async createUserActionSignatureChallenge(request: T.CreateUserActionChallengeRequest): Promise<T.CreateUserActionChallengeResponse> {
+    return this.createUserActionChallenge(request)
+  }
+
+  async createUserActionSignature(request: T.CreateUserActionSignatureRequest): Promise<T.CreateUserActionSignatureResponse> {
+    const path = buildPathAndQuery('/auth/action', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivateApplication(request: T.DeactivateApplicationRequest): Promise<T.DeactivateApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivateCredential(request: T.DeactivateCredentialRequest): Promise<T.DeactivateCredentialResponse> {
+    const path = buildPathAndQuery('/auth/credentials/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivatePersonalAccessToken(request: T.DeactivatePersonalAccessTokenRequest): Promise<T.DeactivatePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivateServiceAccount(request: T.DeactivateServiceAccountRequest): Promise<T.DeactivateServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivateUser(request: T.DeactivateUserRequest): Promise<T.DeactivateUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: {},
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async delegatedLogin(request: T.DelegatedLoginRequest): Promise<T.DelegatedLoginResponse> {
+    const path = buildPathAndQuery('/auth/login/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use delegatedLogin instead */
+  async createDelegatedUserLogin(request: T.DelegatedLoginRequest): Promise<T.DelegatedLoginResponse> {
+    return this.delegatedLogin(request)
+  }
+
+  async getApplication(request: T.GetApplicationRequest): Promise<T.GetApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async getPersonalAccessToken(request: T.GetPersonalAccessTokenRequest): Promise<T.GetPersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async getServiceAccount(request: T.GetServiceAccountRequest): Promise<T.GetServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async getUser(request: T.GetUserRequest): Promise<T.GetUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listApplications(): Promise<T.ListApplicationsResponse> {
+    const path = buildPathAndQuery('/auth/apps', {
+      path: {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listAvailableOrgs(request: T.ListAvailableOrgsRequest): Promise<T.ListAvailableOrgsResponse> {
+    const path = buildPathAndQuery('/auth/login/orgs', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listCredentials(request?: T.ListCredentialsRequest): Promise<T.ListCredentialsResponse> {
+    const path = buildPathAndQuery('/auth/credentials', {
+      path: request ?? {},
+      query: request?.query ?? {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use listCredentials instead */
+  async listUserCredentials(request?: T.ListCredentialsRequest): Promise<T.ListCredentialsResponse> {
+    return this.listCredentials(request)
+  }
+
+  async listPersonalAccessTokens(): Promise<T.ListPersonalAccessTokensResponse> {
+    const path = buildPathAndQuery('/auth/pats', {
+      path: {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listServiceAccounts(): Promise<T.ListServiceAccountsResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts', {
+      path: {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listUsers(request?: T.ListUsersRequest): Promise<T.ListUsersResponse> {
+    const path = buildPathAndQuery('/auth/users', {
+      path: request ?? {},
+      query: request?.query ?? {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async login(request: T.LoginRequest): Promise<T.LoginResponse> {
+    const path = buildPathAndQuery('/auth/login', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async logout(): Promise<T.LogoutResponse> {
+    const path = buildPathAndQuery('/auth/logout', {
+      path: {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async recover(request: T.RecoverRequest): Promise<T.RecoverResponse> {
+    const path = buildPathAndQuery('/auth/recover/user', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use recover instead */
+  async createUserRecovery(request: T.RecoverRequest): Promise<T.RecoverResponse> {
+    return this.recover(request)
+  }
+
+  async recreateDelegatedRegistrationChallenge(request: T.RecreateDelegatedRegistrationChallengeRequest): Promise<T.RecreateDelegatedRegistrationChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/delegated/restart', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use recreateDelegatedRegistrationChallenge instead */
+  async restartDelegatedUserRegistration(request: T.RecreateDelegatedRegistrationChallengeRequest): Promise<T.RecreateDelegatedRegistrationChallengeResponse> {
+    return this.recreateDelegatedRegistrationChallenge(request)
+  }
+
+  async register(request: T.RegisterRequest): Promise<T.RegisterResponse> {
+    const path = buildPathAndQuery('/auth/registration', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use register instead */
+  async createUserRegistration(request: T.RegisterRequest): Promise<T.RegisterResponse> {
+    return this.register(request)
+  }
+
+  async resendRegistrationCode(request: T.ResendRegistrationCodeRequest): Promise<T.ResendRegistrationCodeResponse> {
+    const path = buildPathAndQuery('/auth/registration/code', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async sendRecoveryCode(request: T.SendRecoveryCodeRequest): Promise<T.SendRecoveryCodeResponse> {
+    const path = buildPathAndQuery('/auth/recover/user/code', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async updateApplication(request: T.UpdateApplicationRequest): Promise<T.UpdateApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async updatePersonalAccessToken(request: T.UpdatePersonalAccessTokenRequest): Promise<T.UpdatePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async updateServiceAccount(request: T.UpdateServiceAccountRequest): Promise<T.UpdateServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async updateUser(request: T.UpdateUserRequest): Promise<T.UpdateUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await userActionFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+}

--- a/packages/sdk/generated/auth/delegatedClient.ts
+++ b/packages/sdk/generated/auth/delegatedClient.ts
@@ -1,0 +1,1616 @@
+import { BaseAuthApi, SignUserActionChallengeRequest, UserActionChallengeResponse } from '../../baseAuthApi'
+import { DfnsDelegatedApiClientOptions } from '../../dfnsDelegatedApiClient'
+import { simpleFetch } from '../../utils/fetch'
+import { buildPathAndQuery } from '../../utils/url'
+import * as T from './types'
+
+export class DelegatedAuthClient {
+  constructor(private apiOptions: DfnsDelegatedApiClientOptions) {}
+
+  async activateApplicationInit(request: T.ActivateApplicationRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async activateApplicationComplete(
+    request: T.ActivateApplicationRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ActivateApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async activateCredentialInit(request: T.ActivateCredentialRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async activateCredentialComplete(
+    request: T.ActivateCredentialRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ActivateCredentialResponse> {
+    const path = buildPathAndQuery('/auth/credentials/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async activatePersonalAccessTokenInit(request: T.ActivatePersonalAccessTokenRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async activatePersonalAccessTokenComplete(
+    request: T.ActivatePersonalAccessTokenRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ActivatePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async activateServiceAccountInit(request: T.ActivateServiceAccountRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async activateServiceAccountComplete(
+    request: T.ActivateServiceAccountRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ActivateServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async activateUserInit(request: T.ActivateUserRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async activateUserComplete(
+    request: T.ActivateUserRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ActivateUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId/activate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async archiveApplicationInit(request: T.ArchiveApplicationRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'DELETE',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async archiveApplicationComplete(
+    request: T.ArchiveApplicationRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ArchiveApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'DELETE',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async archivePersonalAccessTokenInit(request: T.ArchivePersonalAccessTokenRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'DELETE',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async archivePersonalAccessTokenComplete(
+    request: T.ArchivePersonalAccessTokenRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ArchivePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'DELETE',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async archiveServiceAccountInit(request: T.ArchiveServiceAccountRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'DELETE',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async archiveServiceAccountComplete(
+    request: T.ArchiveServiceAccountRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ArchiveServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'DELETE',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async archiveUserInit(request: T.ArchiveUserRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'DELETE',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async archiveUserComplete(
+    request: T.ArchiveUserRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ArchiveUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'DELETE',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createApplicationInit(request: T.CreateApplicationRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/apps', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async createApplicationComplete(
+    request: T.CreateApplicationRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.CreateApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createCredentialInit(request: T.CreateCredentialRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/credentials', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async createCredentialComplete(
+    request: T.CreateCredentialRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.CreateCredentialResponse> {
+    const path = buildPathAndQuery('/auth/credentials', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createCredentialChallenge(request: T.CreateCredentialChallengeRequest): Promise<T.CreateCredentialChallengeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use createCredentialChallenge instead */
+  async createUserCredentialChallenge(request: T.CreateCredentialChallengeRequest): Promise<T.CreateCredentialChallengeResponse> {
+    return this.createCredentialChallenge(request)
+  }
+
+  async createCredentialChallengeWithCode(request: T.CreateCredentialChallengeWithCodeRequest): Promise<T.CreateCredentialChallengeWithCodeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/code/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createCredentialCodeInit(request: T.CreateCredentialCodeRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/code', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async createCredentialCodeComplete(
+    request: T.CreateCredentialCodeRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.CreateCredentialCodeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/code', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createCredentialWithCode(request: T.CreateCredentialWithCodeRequest): Promise<T.CreateCredentialWithCodeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/code/verify', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createDelegatedRecoveryChallengeInit(request: T.CreateDelegatedRecoveryChallengeRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/recover/user/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async createDelegatedRecoveryChallengeComplete(
+    request: T.CreateDelegatedRecoveryChallengeRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.CreateDelegatedRecoveryChallengeResponse> {
+    const path = buildPathAndQuery('/auth/recover/user/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createDelegatedRegistrationChallengeInit(request: T.CreateDelegatedRegistrationChallengeRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async createDelegatedRegistrationChallengeComplete(
+    request: T.CreateDelegatedRegistrationChallengeRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.CreateDelegatedRegistrationChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createLoginChallenge(request: T.CreateLoginChallengeRequest): Promise<T.CreateLoginChallengeResponse> {
+    const path = buildPathAndQuery('/auth/login/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createPersonalAccessTokenInit(request: T.CreatePersonalAccessTokenRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/pats', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async createPersonalAccessTokenComplete(
+    request: T.CreatePersonalAccessTokenRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.CreatePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createRecoveryChallenge(request: T.CreateRecoveryChallengeRequest): Promise<T.CreateRecoveryChallengeResponse> {
+    const path = buildPathAndQuery('/auth/recover/user/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createRegistrationChallenge(request: T.CreateRegistrationChallengeRequest): Promise<T.CreateRegistrationChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createServiceAccountInit(request: T.CreateServiceAccountRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async createServiceAccountComplete(
+    request: T.CreateServiceAccountRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.CreateServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createUserInit(request: T.CreateUserRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/users', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async createUserComplete(
+    request: T.CreateUserRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.CreateUserResponse> {
+    const path = buildPathAndQuery('/auth/users', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async createUserActionChallenge(request: T.CreateUserActionChallengeRequest): Promise<T.CreateUserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/action/init', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use createUserActionChallenge instead */
+  async createUserActionSignatureChallenge(request: T.CreateUserActionChallengeRequest): Promise<T.CreateUserActionChallengeResponse> {
+    return this.createUserActionChallenge(request)
+  }
+
+  async createUserActionSignature(request: T.CreateUserActionSignatureRequest): Promise<T.CreateUserActionSignatureResponse> {
+    const path = buildPathAndQuery('/auth/action', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivateApplicationInit(request: T.DeactivateApplicationRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async deactivateApplicationComplete(
+    request: T.DeactivateApplicationRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.DeactivateApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivateCredentialInit(request: T.DeactivateCredentialRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/credentials/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async deactivateCredentialComplete(
+    request: T.DeactivateCredentialRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.DeactivateCredentialResponse> {
+    const path = buildPathAndQuery('/auth/credentials/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivatePersonalAccessTokenInit(request: T.DeactivatePersonalAccessTokenRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async deactivatePersonalAccessTokenComplete(
+    request: T.DeactivatePersonalAccessTokenRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.DeactivatePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivateServiceAccountInit(request: T.DeactivateServiceAccountRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async deactivateServiceAccountComplete(
+    request: T.DeactivateServiceAccountRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.DeactivateServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async deactivateUserInit(request: T.DeactivateUserRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify({}),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async deactivateUserComplete(
+    request: T.DeactivateUserRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.DeactivateUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId/deactivate', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: {},
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async delegatedLoginInit(request: T.DelegatedLoginRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/login/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async delegatedLoginComplete(
+    request: T.DelegatedLoginRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.DelegatedLoginResponse> {
+    const path = buildPathAndQuery('/auth/login/delegated', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async getApplication(request: T.GetApplicationRequest): Promise<T.GetApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async getPersonalAccessToken(request: T.GetPersonalAccessTokenRequest): Promise<T.GetPersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async getServiceAccount(request: T.GetServiceAccountRequest): Promise<T.GetServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async getUser(request: T.GetUserRequest): Promise<T.GetUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listApplications(): Promise<T.ListApplicationsResponse> {
+    const path = buildPathAndQuery('/auth/apps', {
+      path: {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listAvailableOrgs(request: T.ListAvailableOrgsRequest): Promise<T.ListAvailableOrgsResponse> {
+    const path = buildPathAndQuery('/auth/login/orgs', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listCredentials(request?: T.ListCredentialsRequest): Promise<T.ListCredentialsResponse> {
+    const path = buildPathAndQuery('/auth/credentials', {
+      path: request ?? {},
+      query: request?.query ?? {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use listCredentials instead */
+  async listUserCredentials(request?: T.ListCredentialsRequest): Promise<T.ListCredentialsResponse> {
+    return this.listCredentials(request)
+  }
+
+  async listPersonalAccessTokens(): Promise<T.ListPersonalAccessTokensResponse> {
+    const path = buildPathAndQuery('/auth/pats', {
+      path: {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listServiceAccounts(): Promise<T.ListServiceAccountsResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts', {
+      path: {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async listUsers(request?: T.ListUsersRequest): Promise<T.ListUsersResponse> {
+    const path = buildPathAndQuery('/auth/users', {
+      path: request ?? {},
+      query: request?.query ?? {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'GET',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async login(request: T.LoginRequest): Promise<T.LoginResponse> {
+    const path = buildPathAndQuery('/auth/login', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async logout(): Promise<T.LogoutResponse> {
+    const path = buildPathAndQuery('/auth/logout', {
+      path: {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async recover(request: T.RecoverRequest): Promise<T.RecoverResponse> {
+    const path = buildPathAndQuery('/auth/recover/user', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use recover instead */
+  async createUserRecovery(request: T.RecoverRequest): Promise<T.RecoverResponse> {
+    return this.recover(request)
+  }
+
+  async recreateDelegatedRegistrationChallengeInit(request: T.RecreateDelegatedRegistrationChallengeRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/delegated/restart', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async recreateDelegatedRegistrationChallengeComplete(
+    request: T.RecreateDelegatedRegistrationChallengeRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.RecreateDelegatedRegistrationChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/delegated/restart', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async register(request: T.RegisterRequest): Promise<T.RegisterResponse> {
+    const path = buildPathAndQuery('/auth/registration', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+  
+  /** @deprecated, use register instead */
+  async createUserRegistration(request: T.RegisterRequest): Promise<T.RegisterResponse> {
+    return this.register(request)
+  }
+
+  async resendRegistrationCodeInit(request: T.ResendRegistrationCodeRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/registration/code', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async resendRegistrationCodeComplete(
+    request: T.ResendRegistrationCodeRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.ResendRegistrationCodeResponse> {
+    const path = buildPathAndQuery('/auth/registration/code', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async sendRecoveryCode(request: T.SendRecoveryCodeRequest): Promise<T.SendRecoveryCodeResponse> {
+    const path = buildPathAndQuery('/auth/recover/user/code', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async updateApplicationInit(request: T.UpdateApplicationRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async updateApplicationComplete(
+    request: T.UpdateApplicationRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.UpdateApplicationResponse> {
+    const path = buildPathAndQuery('/auth/apps/:appId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'POST',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async updatePersonalAccessTokenInit(request: T.UpdatePersonalAccessTokenRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async updatePersonalAccessTokenComplete(
+    request: T.UpdatePersonalAccessTokenRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.UpdatePersonalAccessTokenResponse> {
+    const path = buildPathAndQuery('/auth/pats/:tokenId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async updateServiceAccountInit(request: T.UpdateServiceAccountRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async updateServiceAccountComplete(
+    request: T.UpdateServiceAccountRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.UpdateServiceAccountResponse> {
+    const path = buildPathAndQuery('/auth/service-accounts/:serviceAccountId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+
+  async updateUserInit(request: T.UpdateUserRequest): Promise<UserActionChallengeResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const challenge = await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionHttpMethod: 'PUT',
+        userActionHttpPath: path,
+        userActionPayload: JSON.stringify(request.body),
+        userActionServerKind: 'Api',
+      },
+      this.apiOptions
+    )
+
+    return challenge
+  }
+
+  async updateUserComplete(
+    request: T.UpdateUserRequest,
+    signedChallenge: SignUserActionChallengeRequest
+  ): Promise<T.UpdateUserResponse> {
+    const path = buildPathAndQuery('/auth/users/:userId', {
+      path: request ?? {},
+      query: {},
+    })
+
+    const { userAction } = await BaseAuthApi.signUserActionChallenge(
+      signedChallenge,
+      this.apiOptions
+    )
+
+    const response = await simpleFetch(path, {
+      method: 'PUT',
+      body: request.body,
+      headers: { 'x-dfns-useraction': userAction },
+      apiOptions: this.apiOptions,
+    })
+
+    return response.json()
+  }
+}

--- a/packages/sdk/generated/auth/index.ts
+++ b/packages/sdk/generated/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './client'
+export * from './delegatedClient'

--- a/packages/sdk/generated/auth/types.ts
+++ b/packages/sdk/generated/auth/types.ts
@@ -1,0 +1,1979 @@
+export type ActivateApplicationParams = {
+    appId: string;
+};
+
+export type ActivateApplicationResponse = {
+    appId: string;
+    kind: "ServerSideApplication" | "ClientSideApplication";
+    orgId: string;
+    expectedRpId: string;
+    name: string;
+    isActive: boolean;
+    expectedOrigin: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type ActivateApplicationRequest = ActivateApplicationParams
+
+export type ActivateCredentialBody = {
+    credentialUuid: string;
+};
+
+export type ActivateCredentialResponse = {
+    message: string;
+};
+
+export type ActivateCredentialRequest = { body: ActivateCredentialBody }
+
+export type ActivatePersonalAccessTokenParams = {
+    tokenId: string;
+};
+
+export type ActivatePersonalAccessTokenResponse = {
+    accessToken?: string | undefined;
+    dateCreated: string;
+    credId: string;
+    isActive: boolean;
+    kind: "ServiceAccount" | "Pat" | "Application";
+    linkedUserId: string;
+    linkedAppId: string;
+    name: string;
+    orgId: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    publicKey: string;
+    tokenId: string;
+};
+
+export type ActivatePersonalAccessTokenRequest = ActivatePersonalAccessTokenParams
+
+export type ActivateServiceAccountParams = {
+    serviceAccountId: string;
+};
+
+export type ActivateServiceAccountResponse = {
+    userInfo: {
+        username: string;
+        userId: string;
+        kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+        credentialUuid: string;
+        orgId: string;
+        permissions?: string[] | undefined;
+        scopes?: string[] | undefined;
+        isActive: boolean;
+        isServiceAccount: boolean;
+        isRegistered: boolean;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+    };
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type ActivateServiceAccountRequest = ActivateServiceAccountParams
+
+export type ActivateUserParams = {
+    userId: string;
+};
+
+export type ActivateUserResponse = {
+    username: string;
+    userId: string;
+    kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+    credentialUuid: string;
+    orgId: string;
+    permissions?: string[] | undefined;
+    scopes?: string[] | undefined;
+    isActive: boolean;
+    isServiceAccount: boolean;
+    isRegistered: boolean;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+};
+
+export type ActivateUserRequest = ActivateUserParams
+
+export type ArchiveApplicationParams = {
+    appId: string;
+};
+
+export type ArchiveApplicationResponse = {
+    appId: string;
+    kind: "ServerSideApplication" | "ClientSideApplication";
+    orgId: string;
+    expectedRpId: string;
+    name: string;
+    isActive: boolean;
+    expectedOrigin: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type ArchiveApplicationRequest = ArchiveApplicationParams
+
+export type ArchivePersonalAccessTokenParams = {
+    tokenId: string;
+};
+
+export type ArchivePersonalAccessTokenResponse = {
+    accessToken?: string | undefined;
+    dateCreated: string;
+    credId: string;
+    isActive: boolean;
+    kind: "ServiceAccount" | "Pat" | "Application";
+    linkedUserId: string;
+    linkedAppId: string;
+    name: string;
+    orgId: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    publicKey: string;
+    tokenId: string;
+};
+
+export type ArchivePersonalAccessTokenRequest = ArchivePersonalAccessTokenParams
+
+export type ArchiveServiceAccountParams = {
+    serviceAccountId: string;
+};
+
+export type ArchiveServiceAccountResponse = {
+    userInfo: {
+        username: string;
+        userId: string;
+        kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+        credentialUuid: string;
+        orgId: string;
+        permissions?: string[] | undefined;
+        scopes?: string[] | undefined;
+        isActive: boolean;
+        isServiceAccount: boolean;
+        isRegistered: boolean;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+    };
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type ArchiveServiceAccountRequest = ArchiveServiceAccountParams
+
+export type ArchiveUserParams = {
+    userId: string;
+};
+
+export type ArchiveUserResponse = {
+    username: string;
+    userId: string;
+    kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+    credentialUuid: string;
+    orgId: string;
+    permissions?: string[] | undefined;
+    scopes?: string[] | undefined;
+    isActive: boolean;
+    isServiceAccount: boolean;
+    isRegistered: boolean;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+};
+
+export type ArchiveUserRequest = ArchiveUserParams
+
+export type CreateApplicationBody = {
+    name: string;
+    relyingPartyId: string;
+    origin: string;
+    permissionId?: string | undefined;
+    kind: "ServerSideApplication" | "ClientSideApplication";
+    daysValid?: number | undefined;
+    publicKey?: (string | undefined) | "";
+    externalId?: string | undefined;
+};
+
+export type CreateApplicationResponse = {
+    appId: string;
+    kind: "ServerSideApplication" | "ClientSideApplication";
+    orgId: string;
+    expectedRpId: string;
+    name: string;
+    isActive: boolean;
+    expectedOrigin: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type CreateApplicationRequest = { body: CreateApplicationBody }
+
+export type CreateCredentialBody = {
+    credentialKind: "Fido2";
+    credentialInfo: {
+        credId: string;
+        clientData: string;
+        attestationData: string;
+    };
+    credentialName: string;
+    challengeIdentifier: string;
+} | {
+    credentialKind: "Key";
+    credentialInfo: {
+        credId: string;
+        clientData: string;
+        attestationData: string;
+    };
+    credentialName: string;
+    challengeIdentifier: string;
+} | {
+    credentialKind: "Password";
+    credentialInfo: {
+        password: string;
+    };
+    credentialName: string;
+    challengeIdentifier: string;
+} | {
+    credentialKind: "Totp";
+    credentialInfo: {
+        otpCode: string;
+    };
+    credentialName: string;
+    challengeIdentifier: string;
+} | {
+    credentialKind: "RecoveryKey";
+    credentialInfo: {
+        credId: string;
+        clientData: string;
+        attestationData: string;
+    };
+    encryptedPrivateKey?: string | undefined;
+    credentialName: string;
+    challengeIdentifier: string;
+};
+
+export type CreateCredentialResponse = {
+    kind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+    credentialId: string;
+    credentialUuid: string;
+    dateCreated: string;
+    isActive: boolean;
+    name: string;
+    publicKey: string;
+    relyingPartyId: string;
+    origin: string;
+};
+
+export type CreateCredentialRequest = { body: CreateCredentialBody }
+
+export type CreateCredentialChallengeBody = {
+    kind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+};
+
+export type CreateCredentialChallengeResponse = {
+    kind: "Password";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+} | {
+    kind: "Totp";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    otpUrl: string;
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+} | {
+    kind: "Fido2";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    authenticatorSelection: {
+        authenticatorAttachment?: ("platform" | "cross-platform") | undefined;
+        residentKey: "required" | "preferred" | "discouraged";
+        requireResidentKey: boolean;
+        userVerification: "required" | "preferred" | "discouraged";
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    excludeCredentials: {
+        type: "public-key";
+        id: string;
+        transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+    }[];
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+} | {
+    kind: "Key";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+} | {
+    kind: "RecoveryKey";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+};
+
+export type CreateCredentialChallengeRequest = { body: CreateCredentialChallengeBody }
+
+export type CreateCredentialChallengeWithCodeBody = {
+    credentialKind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+    code: string;
+};
+
+export type CreateCredentialChallengeWithCodeResponse = {
+    kind: "Password";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+} | {
+    kind: "Totp";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    otpUrl: string;
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+} | {
+    kind: "Fido2";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    authenticatorSelection: {
+        authenticatorAttachment?: ("platform" | "cross-platform") | undefined;
+        residentKey: "required" | "preferred" | "discouraged";
+        requireResidentKey: boolean;
+        userVerification: "required" | "preferred" | "discouraged";
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    excludeCredentials: {
+        type: "public-key";
+        id: string;
+        transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+    }[];
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+} | {
+    kind: "Key";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+} | {
+    kind: "RecoveryKey";
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    challengeIdentifier: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    /** @deprecated use challengeIdentifier instead */
+    temporaryAuthenticationToken: string;
+};
+
+export type CreateCredentialChallengeWithCodeRequest = { body: CreateCredentialChallengeWithCodeBody }
+
+export type CreateCredentialCodeBody = {
+    /** Code expiration, as an ISO-8601 datetime string or a unix timestamp */
+    expiration: string | number;
+};
+
+export type CreateCredentialCodeResponse = {
+    code: string;
+    expiration: string;
+};
+
+export type CreateCredentialCodeRequest = { body: CreateCredentialCodeBody }
+
+export type CreateCredentialWithCodeBody = {
+    credentialKind: "Fido2";
+    credentialInfo: {
+        credId: string;
+        clientData: string;
+        attestationData: string;
+    };
+    credentialName: string;
+    challengeIdentifier: string;
+} | {
+    credentialKind: "Key";
+    credentialInfo: {
+        credId: string;
+        clientData: string;
+        attestationData: string;
+    };
+    credentialName: string;
+    challengeIdentifier: string;
+} | {
+    credentialKind: "Password";
+    credentialInfo: {
+        password: string;
+    };
+    credentialName: string;
+    challengeIdentifier: string;
+} | {
+    credentialKind: "Totp";
+    credentialInfo: {
+        otpCode: string;
+    };
+    credentialName: string;
+    challengeIdentifier: string;
+} | {
+    credentialKind: "RecoveryKey";
+    credentialInfo: {
+        credId: string;
+        clientData: string;
+        attestationData: string;
+    };
+    encryptedPrivateKey?: string | undefined;
+    credentialName: string;
+    challengeIdentifier: string;
+};
+
+export type CreateCredentialWithCodeResponse = {
+    kind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+    credentialId: string;
+    credentialUuid: string;
+    dateCreated: string;
+    isActive: boolean;
+    name: string;
+    publicKey: string;
+    relyingPartyId: string;
+    origin: string;
+};
+
+export type CreateCredentialWithCodeRequest = { body: CreateCredentialWithCodeBody }
+
+export type CreateDelegatedRecoveryChallengeBody = {
+    username: string;
+    credentialId: string;
+};
+
+export type CreateDelegatedRecoveryChallengeResponse = {
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    temporaryAuthenticationToken: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    supportedCredentialKinds: {
+        firstFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+        secondFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+    };
+    authenticatorSelection: {
+        authenticatorAttachment?: ("platform" | "cross-platform") | undefined;
+        residentKey: "required" | "preferred" | "discouraged";
+        requireResidentKey: boolean;
+        userVerification: "required" | "preferred" | "discouraged";
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    excludeCredentials: {
+        type: "public-key";
+        id: string;
+        transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+    }[];
+    otpUrl: string;
+    allowedRecoveryCredentials: {
+        id: string;
+        encryptedRecoveryKey: string;
+    }[];
+};
+
+export type CreateDelegatedRecoveryChallengeRequest = { body: CreateDelegatedRecoveryChallengeBody }
+
+export type CreateDelegatedRegistrationChallengeBody = {
+    email: string;
+    kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+    externalId?: string | undefined;
+};
+
+export type CreateDelegatedRegistrationChallengeResponse = {
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    temporaryAuthenticationToken: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    supportedCredentialKinds: {
+        firstFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+        secondFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+    };
+    authenticatorSelection: {
+        authenticatorAttachment?: ("platform" | "cross-platform") | undefined;
+        residentKey: "required" | "preferred" | "discouraged";
+        requireResidentKey: boolean;
+        userVerification: "required" | "preferred" | "discouraged";
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    excludeCredentials: {
+        type: "public-key";
+        id: string;
+        transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+    }[];
+    otpUrl: string;
+};
+
+export type CreateDelegatedRegistrationChallengeRequest = { body: CreateDelegatedRegistrationChallengeBody }
+
+export type CreateLoginChallengeBody = {
+    username: string;
+    orgId: string;
+};
+
+export type CreateLoginChallengeResponse = {
+    challenge: string;
+    challengeIdentifier: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    supportedCredentialKinds: {
+        kind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+        factor: "first" | "second" | "either";
+        requiresSecondFactor: boolean;
+    }[];
+    userVerification: "required" | "preferred" | "discouraged";
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    allowCredentials: {
+        key: {
+            type: "public-key";
+            id: string;
+            transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+        }[];
+        webauthn: {
+            type: "public-key";
+            id: string;
+            transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+        }[];
+    };
+    externalAuthenticationUrl: string;
+};
+
+export type CreateLoginChallengeRequest = { body: CreateLoginChallengeBody }
+
+export type CreatePersonalAccessTokenBody = {
+    name: string;
+    publicKey: string;
+    permissionId?: string | undefined;
+    externalId?: string | undefined;
+    daysValid?: number | undefined;
+    secondsValid?: number | undefined;
+};
+
+export type CreatePersonalAccessTokenResponse = {
+    accessToken: string;
+    dateCreated: string;
+    credId: string;
+    isActive: boolean;
+    kind: "ServiceAccount" | "Pat" | "Application";
+    linkedUserId: string;
+    linkedAppId: string;
+    name: string;
+    orgId: string;
+    publicKey: string;
+    tokenId: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+};
+
+export type CreatePersonalAccessTokenRequest = { body: CreatePersonalAccessTokenBody }
+
+export type CreateRecoveryChallengeBody = {
+    username: string;
+    verificationCode: string;
+    orgId: string;
+    credentialId: string;
+};
+
+export type CreateRecoveryChallengeResponse = {
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    temporaryAuthenticationToken: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    supportedCredentialKinds: {
+        firstFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+        secondFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+    };
+    authenticatorSelection: {
+        authenticatorAttachment?: ("platform" | "cross-platform") | undefined;
+        residentKey: "required" | "preferred" | "discouraged";
+        requireResidentKey: boolean;
+        userVerification: "required" | "preferred" | "discouraged";
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    excludeCredentials: {
+        type: "public-key";
+        id: string;
+        transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+    }[];
+    otpUrl: string;
+    allowedRecoveryCredentials: {
+        id: string;
+        encryptedRecoveryKey: string;
+    }[];
+};
+
+export type CreateRecoveryChallengeRequest = { body: CreateRecoveryChallengeBody }
+
+export type CreateRegistrationChallengeBody = {
+    orgId: string;
+    username: string;
+    registrationCode: string;
+};
+
+export type CreateRegistrationChallengeResponse = {
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    temporaryAuthenticationToken: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    supportedCredentialKinds: {
+        firstFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+        secondFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+    };
+    authenticatorSelection: {
+        authenticatorAttachment?: ("platform" | "cross-platform") | undefined;
+        residentKey: "required" | "preferred" | "discouraged";
+        requireResidentKey: boolean;
+        userVerification: "required" | "preferred" | "discouraged";
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    excludeCredentials: {
+        type: "public-key";
+        id: string;
+        transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+    }[];
+    otpUrl: string;
+};
+
+export type CreateRegistrationChallengeRequest = { body: CreateRegistrationChallengeBody }
+
+export type CreateServiceAccountBody = {
+    name: string;
+    publicKey: string;
+    permissionId?: string | undefined;
+    externalId?: string | undefined;
+    daysValid?: number | undefined;
+};
+
+export type CreateServiceAccountResponse = {
+    userInfo: {
+        username: string;
+        userId: string;
+        kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+        credentialUuid: string;
+        orgId: string;
+        permissions?: string[] | undefined;
+        scopes?: string[] | undefined;
+        isActive: boolean;
+        isServiceAccount: boolean;
+        isRegistered: boolean;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+    };
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type CreateServiceAccountRequest = { body: CreateServiceAccountBody }
+
+export type CreateUserBody = {
+    email: string;
+    kind: "CustomerEmployee" | "DfnsStaff";
+    publicKey?: string | undefined;
+    externalId?: string | undefined;
+};
+
+export type CreateUserResponse = {
+    username: string;
+    userId: string;
+    kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+    credentialUuid: string;
+    orgId: string;
+    permissions?: string[] | undefined;
+    scopes?: string[] | undefined;
+    isActive: boolean;
+    isServiceAccount: boolean;
+    isRegistered: boolean;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+};
+
+export type CreateUserRequest = { body: CreateUserBody }
+
+export type CreateUserActionChallengeBody = {
+    userActionServerKind?: ("Api" | "Staff") | undefined;
+    userActionHttpMethod: string;
+    userActionHttpPath: string;
+    userActionPayload: string;
+};
+
+export type CreateUserActionChallengeResponse = {
+    challenge: string;
+    challengeIdentifier: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    supportedCredentialKinds: {
+        kind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+        factor: "first" | "second" | "either";
+        requiresSecondFactor: boolean;
+    }[];
+    userVerification: "required" | "preferred" | "discouraged";
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    allowCredentials: {
+        key: {
+            type: "public-key";
+            id: string;
+            transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+        }[];
+        webauthn: {
+            type: "public-key";
+            id: string;
+            transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+        }[];
+    };
+    externalAuthenticationUrl: string;
+};
+
+export type CreateUserActionChallengeRequest = { body: CreateUserActionChallengeBody }
+
+export type CreateUserActionSignatureBody = {
+    challengeIdentifier: string;
+    firstFactor: {
+        kind: "Fido2";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            authenticatorData: string;
+            signature: string;
+            userHandle: string;
+        };
+    } | {
+        kind: "Key";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            signature: string;
+            algorithm?: string | undefined;
+        };
+    } | {
+        kind: "Password";
+        password: string;
+    };
+    secondFactor?: ({
+        kind: "Fido2";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            authenticatorData: string;
+            signature: string;
+            userHandle: string;
+        };
+    } | {
+        kind: "Key";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            signature: string;
+            algorithm?: string | undefined;
+        };
+    } | {
+        kind: "Totp";
+        otpCode: string;
+    }) | undefined;
+};
+
+export type CreateUserActionSignatureResponse = {
+    userAction: string;
+};
+
+export type CreateUserActionSignatureRequest = { body: CreateUserActionSignatureBody }
+
+export type DeactivateApplicationParams = {
+    appId: string;
+};
+
+export type DeactivateApplicationResponse = {
+    appId: string;
+    kind: "ServerSideApplication" | "ClientSideApplication";
+    orgId: string;
+    expectedRpId: string;
+    name: string;
+    isActive: boolean;
+    expectedOrigin: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type DeactivateApplicationRequest = DeactivateApplicationParams
+
+export type DeactivateCredentialBody = {
+    credentialUuid: string;
+};
+
+export type DeactivateCredentialResponse = {
+    message: string;
+};
+
+export type DeactivateCredentialRequest = { body: DeactivateCredentialBody }
+
+export type DeactivatePersonalAccessTokenParams = {
+    tokenId: string;
+};
+
+export type DeactivatePersonalAccessTokenResponse = {
+    accessToken?: string | undefined;
+    dateCreated: string;
+    credId: string;
+    isActive: boolean;
+    kind: "ServiceAccount" | "Pat" | "Application";
+    linkedUserId: string;
+    linkedAppId: string;
+    name: string;
+    orgId: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    publicKey: string;
+    tokenId: string;
+};
+
+export type DeactivatePersonalAccessTokenRequest = DeactivatePersonalAccessTokenParams
+
+export type DeactivateServiceAccountParams = {
+    serviceAccountId: string;
+};
+
+export type DeactivateServiceAccountResponse = {
+    userInfo: {
+        username: string;
+        userId: string;
+        kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+        credentialUuid: string;
+        orgId: string;
+        permissions?: string[] | undefined;
+        scopes?: string[] | undefined;
+        isActive: boolean;
+        isServiceAccount: boolean;
+        isRegistered: boolean;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+    };
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type DeactivateServiceAccountRequest = DeactivateServiceAccountParams
+
+export type DeactivateUserParams = {
+    userId: string;
+};
+
+export type DeactivateUserResponse = {
+    username: string;
+    userId: string;
+    kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+    credentialUuid: string;
+    orgId: string;
+    permissions?: string[] | undefined;
+    scopes?: string[] | undefined;
+    isActive: boolean;
+    isServiceAccount: boolean;
+    isRegistered: boolean;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+};
+
+export type DeactivateUserRequest = DeactivateUserParams
+
+export type DelegatedLoginBody = {
+    username: string;
+};
+
+export type DelegatedLoginResponse = {
+    token: string;
+};
+
+export type DelegatedLoginRequest = { body: DelegatedLoginBody }
+
+export type GetApplicationParams = {
+    appId: string;
+};
+
+export type GetApplicationResponse = {
+    appId: string;
+    kind: "ServerSideApplication" | "ClientSideApplication";
+    orgId: string;
+    expectedRpId: string;
+    name: string;
+    isActive: boolean;
+    expectedOrigin: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type GetApplicationRequest = GetApplicationParams
+
+export type GetPersonalAccessTokenParams = {
+    tokenId: string;
+};
+
+export type GetPersonalAccessTokenResponse = {
+    accessToken?: string | undefined;
+    dateCreated: string;
+    credId: string;
+    isActive: boolean;
+    kind: "ServiceAccount" | "Pat" | "Application";
+    linkedUserId: string;
+    linkedAppId: string;
+    name: string;
+    orgId: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    publicKey: string;
+    tokenId: string;
+};
+
+export type GetPersonalAccessTokenRequest = GetPersonalAccessTokenParams
+
+export type GetServiceAccountParams = {
+    serviceAccountId: string;
+};
+
+export type GetServiceAccountResponse = {
+    userInfo: {
+        username: string;
+        userId: string;
+        kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+        credentialUuid: string;
+        orgId: string;
+        permissions?: string[] | undefined;
+        scopes?: string[] | undefined;
+        isActive: boolean;
+        isServiceAccount: boolean;
+        isRegistered: boolean;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+    };
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type GetServiceAccountRequest = GetServiceAccountParams
+
+export type GetUserParams = {
+    userId: string;
+};
+
+export type GetUserResponse = {
+    username: string;
+    userId: string;
+    kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+    credentialUuid: string;
+    orgId: string;
+    permissions?: string[] | undefined;
+    scopes?: string[] | undefined;
+    isActive: boolean;
+    isServiceAccount: boolean;
+    isRegistered: boolean;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+};
+
+export type GetUserRequest = GetUserParams
+
+export type ListApplicationsResponse = {
+    items: {
+        appId: string;
+        kind: "ServerSideApplication" | "ClientSideApplication";
+        orgId: string;
+        expectedRpId: string;
+        name: string;
+        isActive: boolean;
+        expectedOrigin: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        accessTokens: {
+            accessToken?: string | undefined;
+            dateCreated: string;
+            credId: string;
+            isActive: boolean;
+            kind: "ServiceAccount" | "Pat" | "Application";
+            linkedUserId: string;
+            linkedAppId: string;
+            name: string;
+            orgId: string;
+            permissionAssignments: {
+                permissionName: string;
+                permissionId: string;
+                assignmentId: string;
+                operations?: string[] | undefined;
+            }[];
+            publicKey: string;
+            tokenId: string;
+        }[];
+    }[];
+};
+
+export type ListAvailableOrgsBody = {
+    username: string;
+    orgId?: string | undefined;
+    permissions?: string[] | undefined;
+    origin: string;
+};
+
+export type ListAvailableOrgsResponse = {
+    items: {
+        orgId: string;
+        appId: string;
+    }[];
+};
+
+export type ListAvailableOrgsRequest = { body: ListAvailableOrgsBody }
+
+export type ListCredentialsQuery = {};
+
+export type ListCredentialsResponse = {
+    items: {
+        kind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+        credentialId: string;
+        credentialUuid: string;
+        dateCreated: string;
+        isActive: boolean;
+        name: string;
+        publicKey: string;
+        relyingPartyId: string;
+        origin: string;
+    }[];
+};
+
+export type ListCredentialsRequest = { query?: ListCredentialsQuery }
+
+export type ListPersonalAccessTokensResponse = {
+    items: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type ListServiceAccountsResponse = {
+    items: {
+        userInfo: {
+            username: string;
+            userId: string;
+            kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+            credentialUuid: string;
+            orgId: string;
+            permissions?: string[] | undefined;
+            scopes?: string[] | undefined;
+            isActive: boolean;
+            isServiceAccount: boolean;
+            isRegistered: boolean;
+            permissionAssignments: {
+                permissionName: string;
+                permissionId: string;
+                assignmentId: string;
+                operations?: string[] | undefined;
+            }[];
+        };
+        accessTokens: {
+            accessToken?: string | undefined;
+            dateCreated: string;
+            credId: string;
+            isActive: boolean;
+            kind: "ServiceAccount" | "Pat" | "Application";
+            linkedUserId: string;
+            linkedAppId: string;
+            name: string;
+            orgId: string;
+            permissionAssignments: {
+                permissionName: string;
+                permissionId: string;
+                assignmentId: string;
+                operations?: string[] | undefined;
+            }[];
+            publicKey: string;
+            tokenId: string;
+        }[];
+    }[];
+};
+
+export type ListUsersQuery = {
+    limit?: number | undefined;
+    paginationToken?: string | undefined;
+    kind?: ("CustomerEmployee" | "EndUser") | undefined;
+};
+
+export type ListUsersResponse = {
+    items: {
+        username: string;
+        userId: string;
+        kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+        credentialUuid: string;
+        orgId: string;
+        permissions?: string[] | undefined;
+        scopes?: string[] | undefined;
+        isActive: boolean;
+        isServiceAccount: boolean;
+        isRegistered: boolean;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+    }[];
+    nextPageToken?: string | undefined;
+};
+
+export type ListUsersRequest = { query?: ListUsersQuery }
+
+export type LoginBody = {
+    challengeIdentifier: string;
+    firstFactor: {
+        kind: "Fido2";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            authenticatorData: string;
+            signature: string;
+            userHandle: string;
+        };
+    } | {
+        kind: "Key";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            signature: string;
+            algorithm?: string | undefined;
+        };
+    } | {
+        kind: "Password";
+        password: string;
+    };
+    secondFactor?: ({
+        kind: "Fido2";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            authenticatorData: string;
+            signature: string;
+            userHandle: string;
+        };
+    } | {
+        kind: "Key";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            signature: string;
+            algorithm?: string | undefined;
+        };
+    } | {
+        kind: "Totp";
+        otpCode: string;
+    }) | undefined;
+};
+
+export type LoginResponse = {
+    token: string;
+};
+
+export type LoginRequest = { body: LoginBody }
+
+export type LogoutResponse = {
+    message: string;
+};
+
+export type RecoverBody = {
+    recovery: {
+        kind: "RecoveryKey";
+        credentialAssertion: {
+            credId: string;
+            clientData: string;
+            signature: string;
+            algorithm?: string | undefined;
+        };
+    };
+    newCredentials: {
+        firstFactorCredential: {
+            credentialKind: "Fido2";
+            credentialInfo: {
+                credId: string;
+                clientData: string;
+                attestationData: string;
+            };
+        } | {
+            credentialKind: "Key";
+            credentialInfo: {
+                credId: string;
+                clientData: string;
+                attestationData: string;
+            };
+        } | {
+            credentialKind: "Password";
+            credentialInfo: {
+                password: string;
+            };
+        };
+        secondFactorCredential?: ({
+            credentialKind: "Fido2";
+            credentialInfo: {
+                credId: string;
+                clientData: string;
+                attestationData: string;
+            };
+        } | {
+            credentialKind: "Key";
+            credentialInfo: {
+                credId: string;
+                clientData: string;
+                attestationData: string;
+            };
+        } | {
+            credentialKind: "Totp";
+            credentialInfo: {
+                otpCode: string;
+            };
+        }) | undefined;
+        recoveryCredential?: {
+            credentialKind: "RecoveryKey";
+            credentialInfo: {
+                credId: string;
+                clientData: string;
+                attestationData: string;
+            };
+            encryptedPrivateKey?: string | undefined;
+        } | undefined;
+    };
+};
+
+export type RecoverResponse = {
+    credential: {
+        uuid: string;
+        kind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+        name: string;
+    };
+    user: {
+        id: string;
+        username: string;
+        orgId: string;
+    };
+};
+
+export type RecoverRequest = { body: RecoverBody }
+
+export type RecreateDelegatedRegistrationChallengeBody = {
+    email: string;
+    kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+    externalId?: string | undefined;
+};
+
+export type RecreateDelegatedRegistrationChallengeResponse = {
+    user: {
+        id: string;
+        displayName: string;
+        name: string;
+    };
+    temporaryAuthenticationToken: string;
+    challenge: string;
+    rp: {
+        id: string;
+        name: string;
+    };
+    supportedCredentialKinds: {
+        firstFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+        secondFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey")[];
+    };
+    authenticatorSelection: {
+        authenticatorAttachment?: ("platform" | "cross-platform") | undefined;
+        residentKey: "required" | "preferred" | "discouraged";
+        requireResidentKey: boolean;
+        userVerification: "required" | "preferred" | "discouraged";
+    };
+    attestation: "none" | "indirect" | "direct" | "enterprise";
+    pubKeyCredParams: {
+        type: string;
+        alg: number;
+    }[];
+    excludeCredentials: {
+        type: "public-key";
+        id: string;
+        transports?: ("usb" | "nfc" | "ble" | "smart-card" | "hybrid" | "internal") | undefined;
+    }[];
+    otpUrl: string;
+};
+
+export type RecreateDelegatedRegistrationChallengeRequest = { body: RecreateDelegatedRegistrationChallengeBody }
+
+export type RegisterBody = {
+    firstFactorCredential: {
+        credentialKind: "Fido2";
+        credentialInfo: {
+            credId: string;
+            clientData: string;
+            attestationData: string;
+        };
+    } | {
+        credentialKind: "Key";
+        credentialInfo: {
+            credId: string;
+            clientData: string;
+            attestationData: string;
+        };
+    } | {
+        credentialKind: "Password";
+        credentialInfo: {
+            password: string;
+        };
+    };
+    secondFactorCredential?: ({
+        credentialKind: "Fido2";
+        credentialInfo: {
+            credId: string;
+            clientData: string;
+            attestationData: string;
+        };
+    } | {
+        credentialKind: "Key";
+        credentialInfo: {
+            credId: string;
+            clientData: string;
+            attestationData: string;
+        };
+    } | {
+        credentialKind: "Totp";
+        credentialInfo: {
+            otpCode: string;
+        };
+    }) | undefined;
+    recoveryCredential?: {
+        credentialKind: "RecoveryKey";
+        credentialInfo: {
+            credId: string;
+            clientData: string;
+            attestationData: string;
+        };
+        encryptedPrivateKey?: string | undefined;
+    } | undefined;
+};
+
+export type RegisterResponse = {
+    credential: {
+        uuid: string;
+        kind: "Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey";
+        name: string;
+    };
+    user: {
+        id: string;
+        username: string;
+        orgId: string;
+    };
+};
+
+export type RegisterRequest = { body: RegisterBody }
+
+export type ResendRegistrationCodeBody = {
+    username: string;
+    orgId: string;
+};
+
+export type ResendRegistrationCodeResponse = {
+    message: string;
+};
+
+export type ResendRegistrationCodeRequest = { body: ResendRegistrationCodeBody }
+
+export type SendRecoveryCodeBody = {
+    username: string;
+    orgId: string;
+};
+
+export type SendRecoveryCodeResponse = {
+    message: string;
+};
+
+export type SendRecoveryCodeRequest = { body: SendRecoveryCodeBody }
+
+export type UpdateApplicationBody = {
+    externalId?: string | undefined;
+    name?: string | undefined;
+};
+
+export type UpdateApplicationParams = {
+    appId: string;
+};
+
+export type UpdateApplicationResponse = {
+    appId: string;
+    kind: "ServerSideApplication" | "ClientSideApplication";
+    orgId: string;
+    expectedRpId: string;
+    name: string;
+    isActive: boolean;
+    expectedOrigin: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type UpdateApplicationRequest = UpdateApplicationParams & { body: UpdateApplicationBody }
+
+export type UpdatePersonalAccessTokenBody = {
+    name?: string | undefined;
+    externalId?: string | undefined;
+};
+
+export type UpdatePersonalAccessTokenParams = {
+    tokenId: string;
+};
+
+export type UpdatePersonalAccessTokenResponse = {
+    accessToken?: string | undefined;
+    dateCreated: string;
+    credId: string;
+    isActive: boolean;
+    kind: "ServiceAccount" | "Pat" | "Application";
+    linkedUserId: string;
+    linkedAppId: string;
+    name: string;
+    orgId: string;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+    publicKey: string;
+    tokenId: string;
+};
+
+export type UpdatePersonalAccessTokenRequest = UpdatePersonalAccessTokenParams & { body: UpdatePersonalAccessTokenBody }
+
+export type UpdateServiceAccountBody = {
+    name?: string | undefined;
+    externalId?: string | undefined;
+};
+
+export type UpdateServiceAccountParams = {
+    serviceAccountId: string;
+};
+
+export type UpdateServiceAccountResponse = {
+    userInfo: {
+        username: string;
+        userId: string;
+        kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+        credentialUuid: string;
+        orgId: string;
+        permissions?: string[] | undefined;
+        scopes?: string[] | undefined;
+        isActive: boolean;
+        isServiceAccount: boolean;
+        isRegistered: boolean;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+    };
+    accessTokens: {
+        accessToken?: string | undefined;
+        dateCreated: string;
+        credId: string;
+        isActive: boolean;
+        kind: "ServiceAccount" | "Pat" | "Application";
+        linkedUserId: string;
+        linkedAppId: string;
+        name: string;
+        orgId: string;
+        permissionAssignments: {
+            permissionName: string;
+            permissionId: string;
+            assignmentId: string;
+            operations?: string[] | undefined;
+        }[];
+        publicKey: string;
+        tokenId: string;
+    }[];
+};
+
+export type UpdateServiceAccountRequest = UpdateServiceAccountParams & { body: UpdateServiceAccountBody }
+
+export type UpdateUserBody = {
+    externalId?: string | undefined;
+    publicKey?: string | undefined;
+};
+
+export type UpdateUserParams = {
+    userId: string;
+};
+
+export type UpdateUserResponse = {
+    username: string;
+    userId: string;
+    kind: "EndUser" | "CustomerEmployee" | "DfnsStaff";
+    credentialUuid: string;
+    orgId: string;
+    permissions?: string[] | undefined;
+    scopes?: string[] | undefined;
+    isActive: boolean;
+    isServiceAccount: boolean;
+    isRegistered: boolean;
+    permissionAssignments: {
+        permissionName: string;
+        permissionId: string;
+        assignmentId: string;
+        operations?: string[] | undefined;
+    }[];
+};
+
+export type UpdateUserRequest = UpdateUserParams & { body: UpdateUserBody }
+

--- a/packages/sdk/generated/networks/types.ts
+++ b/packages/sdk/generated/networks/types.ts
@@ -7,16 +7,16 @@ export type GetFeesResponse = {
     network: "ArbitrumOne" | "ArbitrumGoerli" | "ArbitrumSepolia" | "AvalancheC" | "AvalancheCFuji" | "Base" | "BaseGoerli" | "BaseSepolia" | "Bsc" | "BscTestnet" | "Ethereum" | "EthereumGoerli" | "EthereumSepolia" | "FantomOpera" | "FantomTestnet" | "Optimism" | "OptimismGoerli" | "OptimismSepolia" | "Polygon" | "PolygonAmoy" | "PolygonMumbai";
     blockNumber: number;
     slow: {
-        maxPriorityFee: number;
-        maxFee: number;
+        maxPriorityFeePerGas: string;
+        maxFeePerGas: string;
     };
     standard: {
-        maxPriorityFee: number;
-        maxFee: number;
+        maxPriorityFeePerGas: string;
+        maxFeePerGas: string;
     };
     fast: {
-        maxPriorityFee: number;
-        maxFee: number;
+        maxPriorityFeePerGas: string;
+        maxFeePerGas: string;
     };
     estimatedBaseFee: number;
 };

--- a/packages/sdk/generated/permissions/types.ts
+++ b/packages/sdk/generated/permissions/types.ts
@@ -10,12 +10,10 @@ export type ArchivePermissionResponse = {
     id: string;
     name: string;
     operations: string[];
-    resourceId?: (string | undefined) | null;
     status: "Active";
-    predicateIds?: string[] | undefined;
     isImmutable: boolean;
-    dateCreated?: string | undefined;
-    dateUpdated?: string | undefined;
+    dateCreated: string;
+    dateUpdated: string;
     isArchived: boolean;
 };
 
@@ -34,27 +32,25 @@ export type CreateAssignmentResponse = {
     permissionId: string;
     identityId: string;
     isImmutable: boolean;
-    dateCreated?: string | undefined;
-    dateUpdated?: string | undefined;
+    dateCreated: string;
+    dateUpdated: string;
 };
 
 export type CreateAssignmentRequest = CreateAssignmentParams & { body: CreateAssignmentBody }
 
 export type CreatePermissionBody = {
     name: string;
-    operations: ("ApiKeys:Create" | "ApiKeys:Read" | "ApiKeys:Revoke" | "AssetAccounts:Archive" | "AssetAccounts:Create" | "AssetAccounts:Read" | "Auth:Action:Sign" | "Auth:Apps:Create" | "Auth:Apps:Read" | "Auth:Apps:Update" | "Auth:Creds:Create" | "Auth:Creds:Read" | "Auth:Creds:Update" | "Auth:Types:Application" | "Auth:Types:Employee" | "Auth:Types:EndUser" | "Auth:Types:Pat" | "Auth:Types:ServiceAccount" | "Auth:Users:Create" | "Auth:Users:Delegate" | "Auth:Users:Read" | "Auth:Users:Update" | "Balances:Read" | "CallbackEvents:Read" | "CallbackSubscriptions:Archive" | "CallbackSubscriptions:Create" | "CallbackSubscriptions:Read" | "Employees:Read" | "Payments:Create" | "Payments:Read" | "PermissionAssignments:Create" | "PermissionAssignments:Read" | "PermissionAssignments:Revoke" | "PermissionPredicates:Archive" | "PermissionPredicates:Create" | "PermissionPredicates:Read" | "PermissionPredicates:Update" | "Permissions:Archive" | "Permissions:Create" | "Permissions:Read" | "Permissions:Update" | "Policies:Archive" | "Policies:Create" | "Policies:Read" | "Policies:Update" | "Policies:Approvals:Read" | "Policies:Approvals:Approve" | "PolicyControlExecutions:Read" | "PolicyControlExecutions:Update" | "PolicyControls:Archive" | "PolicyControls:Create" | "PolicyControls:Read" | "PolicyControls:Update" | "PolicyRules:Archive" | "PolicyRules:Create" | "PolicyRules:Read" | "PolicyRules:Update" | "PublicKeyAddresses:Read" | "PublicKeys:Create" | "PublicKeys:Read" | "Signatures:Create" | "Signatures:Read" | "Signers:ListSigners" | "Transactions:Create" | "Transactions:Read" | "Wallets:BroadcastTransaction" | "Wallets:Create" | "Wallets:Delegate" | "Wallets:Export" | "Wallets:GenerateSignature" | "Wallets:Import" | "Wallets:Read" | "Wallets:ReadSignature" | "Wallets:ReadTransaction" | "Wallets:ReadTransfer" | "Wallets:TransferAsset" | "Wallets:Update" | "Webhooks:Create" | "Webhooks:Read" | "Webhooks:Update" | "Webhooks:Delete" | "Webhooks:Ping" | "Webhooks:Events:Read")[];
+    operations: ("ApiKeys:Create" | "ApiKeys:Read" | "ApiKeys:Revoke" | "AssetAccounts:Archive" | "AssetAccounts:Create" | "AssetAccounts:Read" | "Auth:Action:Sign" | "Auth:Apps:Create" | "Auth:Apps:Read" | "Auth:Apps:Update" | "Auth:Creds:Create" | "Auth:Creds:Read" | "Auth:Creds:Update" | "Auth:Creds:Code:Create" | "Auth:Types:Application" | "Auth:Types:Employee" | "Auth:Types:EndUser" | "Auth:Types:Pat" | "Auth:Types:ServiceAccount" | "Auth:Users:Create" | "Auth:Users:Delegate" | "Auth:Users:Read" | "Auth:Users:Update" | "Balances:Read" | "CallbackEvents:Read" | "CallbackSubscriptions:Archive" | "CallbackSubscriptions:Create" | "CallbackSubscriptions:Read" | "Employees:Read" | "Payments:Create" | "Payments:Read" | "PermissionAssignments:Create" | "PermissionAssignments:Read" | "PermissionAssignments:Revoke" | "PermissionPredicates:Archive" | "PermissionPredicates:Create" | "PermissionPredicates:Read" | "PermissionPredicates:Update" | "Permissions:Archive" | "Permissions:Create" | "Permissions:Read" | "Permissions:Update" | "Policies:Archive" | "Policies:Create" | "Policies:Read" | "Policies:Update" | "Policies:Approvals:Read" | "Policies:Approvals:Approve" | "PolicyControlExecutions:Read" | "PolicyControlExecutions:Update" | "PolicyControls:Archive" | "PolicyControls:Create" | "PolicyControls:Read" | "PolicyControls:Update" | "PolicyRules:Archive" | "PolicyRules:Create" | "PolicyRules:Read" | "PolicyRules:Update" | "PublicKeyAddresses:Read" | "PublicKeys:Create" | "PublicKeys:Read" | "Signatures:Create" | "Signatures:Read" | "Signers:ListSigners" | "Transactions:Create" | "Transactions:Read" | "Wallets:BroadcastTransaction" | "Wallets:Create" | "Wallets:Delegate" | "Wallets:Export" | "Wallets:GenerateSignature" | "Wallets:Import" | "Wallets:Read" | "Wallets:ReadSignature" | "Wallets:ReadTransaction" | "Wallets:ReadTransfer" | "Wallets:TransferAsset" | "Wallets:Update" | "Webhooks:Create" | "Webhooks:Read" | "Webhooks:Update" | "Webhooks:Delete" | "Webhooks:Ping" | "Webhooks:Events:Read")[];
 };
 
 export type CreatePermissionResponse = {
     id: string;
     name: string;
     operations: string[];
-    resourceId?: (string | undefined) | null;
     status: "Active";
-    predicateIds?: string[] | undefined;
     isImmutable: boolean;
-    dateCreated?: string | undefined;
-    dateUpdated?: string | undefined;
+    dateCreated: string;
+    dateUpdated: string;
     isArchived: boolean;
 };
 
@@ -77,12 +73,10 @@ export type GetPermissionResponse = {
     id: string;
     name: string;
     operations: string[];
-    resourceId?: (string | undefined) | null;
     status: "Active";
-    predicateIds?: string[] | undefined;
     isImmutable: boolean;
-    dateCreated?: string | undefined;
-    dateUpdated?: string | undefined;
+    dateCreated: string;
+    dateUpdated: string;
     isArchived: boolean;
 } & {
     pendingChangeRequest?: {
@@ -113,8 +107,8 @@ export type ListAssignmentsResponse = {
         permissionId: string;
         identityId: string;
         isImmutable: boolean;
-        dateCreated?: string | undefined;
-        dateUpdated?: string | undefined;
+        dateCreated: string;
+        dateUpdated: string;
     } & {
         pendingChangeRequest?: {
             id: string;
@@ -146,12 +140,10 @@ export type ListPermissionsResponse = {
         id: string;
         name: string;
         operations: string[];
-        resourceId?: (string | undefined) | null;
         status: "Active";
-        predicateIds?: string[] | undefined;
         isImmutable: boolean;
-        dateCreated?: string | undefined;
-        dateUpdated?: string | undefined;
+        dateCreated: string;
+        dateUpdated: string;
         isArchived: boolean;
     } & {
         pendingChangeRequest?: {
@@ -176,7 +168,7 @@ export type ListPermissionsRequest = { query?: ListPermissionsQuery }
 
 export type UpdatePermissionBody = {
     name?: string | undefined;
-    operations?: ("ApiKeys:Create" | "ApiKeys:Read" | "ApiKeys:Revoke" | "AssetAccounts:Archive" | "AssetAccounts:Create" | "AssetAccounts:Read" | "Auth:Action:Sign" | "Auth:Apps:Create" | "Auth:Apps:Read" | "Auth:Apps:Update" | "Auth:Creds:Create" | "Auth:Creds:Read" | "Auth:Creds:Update" | "Auth:Types:Application" | "Auth:Types:Employee" | "Auth:Types:EndUser" | "Auth:Types:Pat" | "Auth:Types:ServiceAccount" | "Auth:Users:Create" | "Auth:Users:Delegate" | "Auth:Users:Read" | "Auth:Users:Update" | "Balances:Read" | "CallbackEvents:Read" | "CallbackSubscriptions:Archive" | "CallbackSubscriptions:Create" | "CallbackSubscriptions:Read" | "Employees:Read" | "Payments:Create" | "Payments:Read" | "PermissionAssignments:Create" | "PermissionAssignments:Read" | "PermissionAssignments:Revoke" | "PermissionPredicates:Archive" | "PermissionPredicates:Create" | "PermissionPredicates:Read" | "PermissionPredicates:Update" | "Permissions:Archive" | "Permissions:Create" | "Permissions:Read" | "Permissions:Update" | "Policies:Archive" | "Policies:Create" | "Policies:Read" | "Policies:Update" | "Policies:Approvals:Read" | "Policies:Approvals:Approve" | "PolicyControlExecutions:Read" | "PolicyControlExecutions:Update" | "PolicyControls:Archive" | "PolicyControls:Create" | "PolicyControls:Read" | "PolicyControls:Update" | "PolicyRules:Archive" | "PolicyRules:Create" | "PolicyRules:Read" | "PolicyRules:Update" | "PublicKeyAddresses:Read" | "PublicKeys:Create" | "PublicKeys:Read" | "Signatures:Create" | "Signatures:Read" | "Signers:ListSigners" | "Transactions:Create" | "Transactions:Read" | "Wallets:BroadcastTransaction" | "Wallets:Create" | "Wallets:Delegate" | "Wallets:Export" | "Wallets:GenerateSignature" | "Wallets:Import" | "Wallets:Read" | "Wallets:ReadSignature" | "Wallets:ReadTransaction" | "Wallets:ReadTransfer" | "Wallets:TransferAsset" | "Wallets:Update" | "Webhooks:Create" | "Webhooks:Read" | "Webhooks:Update" | "Webhooks:Delete" | "Webhooks:Ping" | "Webhooks:Events:Read")[] | undefined;
+    operations?: ("ApiKeys:Create" | "ApiKeys:Read" | "ApiKeys:Revoke" | "AssetAccounts:Archive" | "AssetAccounts:Create" | "AssetAccounts:Read" | "Auth:Action:Sign" | "Auth:Apps:Create" | "Auth:Apps:Read" | "Auth:Apps:Update" | "Auth:Creds:Create" | "Auth:Creds:Read" | "Auth:Creds:Update" | "Auth:Creds:Code:Create" | "Auth:Types:Application" | "Auth:Types:Employee" | "Auth:Types:EndUser" | "Auth:Types:Pat" | "Auth:Types:ServiceAccount" | "Auth:Users:Create" | "Auth:Users:Delegate" | "Auth:Users:Read" | "Auth:Users:Update" | "Balances:Read" | "CallbackEvents:Read" | "CallbackSubscriptions:Archive" | "CallbackSubscriptions:Create" | "CallbackSubscriptions:Read" | "Employees:Read" | "Payments:Create" | "Payments:Read" | "PermissionAssignments:Create" | "PermissionAssignments:Read" | "PermissionAssignments:Revoke" | "PermissionPredicates:Archive" | "PermissionPredicates:Create" | "PermissionPredicates:Read" | "PermissionPredicates:Update" | "Permissions:Archive" | "Permissions:Create" | "Permissions:Read" | "Permissions:Update" | "Policies:Archive" | "Policies:Create" | "Policies:Read" | "Policies:Update" | "Policies:Approvals:Read" | "Policies:Approvals:Approve" | "PolicyControlExecutions:Read" | "PolicyControlExecutions:Update" | "PolicyControls:Archive" | "PolicyControls:Create" | "PolicyControls:Read" | "PolicyControls:Update" | "PolicyRules:Archive" | "PolicyRules:Create" | "PolicyRules:Read" | "PolicyRules:Update" | "PublicKeyAddresses:Read" | "PublicKeys:Create" | "PublicKeys:Read" | "Signatures:Create" | "Signatures:Read" | "Signers:ListSigners" | "Transactions:Create" | "Transactions:Read" | "Wallets:BroadcastTransaction" | "Wallets:Create" | "Wallets:Delegate" | "Wallets:Export" | "Wallets:GenerateSignature" | "Wallets:Import" | "Wallets:Read" | "Wallets:ReadSignature" | "Wallets:ReadTransaction" | "Wallets:ReadTransfer" | "Wallets:TransferAsset" | "Wallets:Update" | "Webhooks:Create" | "Webhooks:Read" | "Webhooks:Update" | "Webhooks:Delete" | "Webhooks:Ping" | "Webhooks:Events:Read")[] | undefined;
 };
 
 export type UpdatePermissionParams = {
@@ -187,12 +179,10 @@ export type UpdatePermissionResponse = {
     id: string;
     name: string;
     operations: string[];
-    resourceId?: (string | undefined) | null;
     status: "Active";
-    predicateIds?: string[] | undefined;
     isImmutable: boolean;
-    dateCreated?: string | undefined;
-    dateUpdated?: string | undefined;
+    dateCreated: string;
+    dateUpdated: string;
     isArchived: boolean;
 };
 

--- a/packages/sdk/generated/wallets/types.ts
+++ b/packages/sdk/generated/wallets/types.ts
@@ -407,16 +407,19 @@ export type GetTransferResponse = {
         to: string | string | string | string | string | string | string | string | string | string;
         amount: string;
         memo?: string | undefined;
+        priority?: ("Slow" | "Standard" | "Fast") | undefined;
     } | {
         kind: "Erc20";
         contract: string;
         to: string;
         amount: string;
+        priority?: ("Slow" | "Standard" | "Fast") | undefined;
     } | {
         kind: "Erc721";
         contract: string;
         to: string;
         tokenId: string;
+        priority?: ("Slow" | "Standard" | "Fast") | undefined;
     } | {
         kind: "Trc10";
         tokenId: string;
@@ -1024,16 +1027,19 @@ export type ListTransfersResponse = {
             to: string | string | string | string | string | string | string | string | string | string;
             amount: string;
             memo?: string | undefined;
+            priority?: ("Slow" | "Standard" | "Fast") | undefined;
         } | {
             kind: "Erc20";
             contract: string;
             to: string;
             amount: string;
+            priority?: ("Slow" | "Standard" | "Fast") | undefined;
         } | {
             kind: "Erc721";
             contract: string;
             to: string;
             tokenId: string;
+            priority?: ("Slow" | "Standard" | "Fast") | undefined;
         } | {
             kind: "Trc10";
             tokenId: string;
@@ -1114,16 +1120,19 @@ export type TransferAssetBody = {
     to: string | string | string | string | string | string | string | string | string | string;
     amount: string;
     memo?: string | undefined;
+    priority?: ("Slow" | "Standard" | "Fast") | undefined;
 } | {
     kind: "Erc20";
     contract: string;
     to: string;
     amount: string;
+    priority?: ("Slow" | "Standard" | "Fast") | undefined;
 } | {
     kind: "Erc721";
     contract: string;
     to: string;
     tokenId: string;
+    priority?: ("Slow" | "Standard" | "Fast") | undefined;
 } | {
     kind: "Trc10";
     tokenId: string;
@@ -1164,16 +1173,19 @@ export type TransferAssetResponse = {
         to: string | string | string | string | string | string | string | string | string | string;
         amount: string;
         memo?: string | undefined;
+        priority?: ("Slow" | "Standard" | "Fast") | undefined;
     } | {
         kind: "Erc20";
         contract: string;
         to: string;
         amount: string;
+        priority?: ("Slow" | "Standard" | "Fast") | undefined;
     } | {
         kind: "Erc721";
         contract: string;
         to: string;
         tokenId: string;
+        priority?: ("Slow" | "Standard" | "Fast") | undefined;
     } | {
         kind: "Trc10";
         tokenId: string;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@dfns/sdk",
-  "version": "0.4.1"
+  "version": "0.4.2-alpha.1"
 }

--- a/packages/sdk/signer.ts
+++ b/packages/sdk/signer.ts
@@ -86,9 +86,3 @@ export type CredentialAssertion = KeyAssertion | Fido2Assertion | PasswordAssert
 export interface CredentialSigner<T extends CredentialAssertion = FirstFactorAssertion> {
   sign(challenge: UserActionChallenge): Promise<T>
 }
-
-export class EmptySigner implements CredentialSigner {
-  async sign(): Promise<never> {
-    throw new DfnsError(-1, 'A signature is required, but an EmptySigner cannot fulfill it.')
-  }
-}

--- a/packages/sdk/signer.ts
+++ b/packages/sdk/signer.ts
@@ -1,3 +1,5 @@
+import { DfnsError } from './dfnsError'
+
 export type CredentialFactor = 'first' | 'second' | 'either'
 
 export type CredentialKind = 'Key' | 'Fido2' | 'Password' | 'Totp' | 'RecoveryKey'
@@ -83,4 +85,10 @@ export type CredentialAssertion = KeyAssertion | Fido2Assertion | PasswordAssert
 
 export interface CredentialSigner<T extends CredentialAssertion = FirstFactorAssertion> {
   sign(challenge: UserActionChallenge): Promise<T>
+}
+
+export class EmptySigner implements CredentialSigner {
+  async sign(): Promise<never> {
+    throw new DfnsError(-1, 'A signature is required, but an EmptySigner cannot fulfill it.')
+  }
 }

--- a/packages/sdk/types/auth.ts
+++ b/packages/sdk/types/auth.ts
@@ -1,0 +1,1 @@
+export * from '../generated/auth'


### PR DESCRIPTION
- switch `AuthClient` to the newly generated client (from `/generated/auth/client`)
- update examples to use the newly named auth methods, instead of the deprecated names
- create a `EmptySigner` class
- some other api changes reflected after SDK generation:
  - networks client: `maxFee` -> `maxFeePerGas`
  - wallet client:  `maxPriorityFee` -> `maxPriorityFeePerGas` change
  - permissions client: `dateCreated` and `dateUpdated` are not optional + `Auth:Creds:Code:Create` permission added
  - wallet client: added optional `priority` field