### PR TITLE
Add externalId to transfer, transaction, signature

### DIFF
--- a/packages/sdk/generated/exchanges/types.ts
+++ b/packages/sdk/generated/exchanges/types.ts
@@ -2,6 +2,7 @@ export type CreateDepositBody = {
     kind: "Native";
     amount: string;
     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
@@ -9,24 +10,28 @@ export type CreateDepositBody = {
     contract: string;
     amount: string;
     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
     kind: "Trc10";
     tokenId: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
     kind: "Trc20";
     contract: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
     kind: "Asa";
     assetId: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
@@ -34,6 +39,7 @@ export type CreateDepositBody = {
     issuer: string;
     assetCode: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
@@ -41,12 +47,14 @@ export type CreateDepositBody = {
     amount: string;
     mint: string;
     createDestinationAccount?: boolean | undefined;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
     kind: "Tep74";
     master: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 };
@@ -73,6 +81,7 @@ export type CreateDepositResponse = {
         kind: "Native";
         amount: string;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
@@ -80,24 +89,28 @@ export type CreateDepositResponse = {
         contract: string;
         amount: string;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
         kind: "Trc10";
         tokenId: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
         kind: "Trc20";
         contract: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
         kind: "Asa";
         assetId: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
@@ -105,6 +118,7 @@ export type CreateDepositResponse = {
         issuer: string;
         assetCode: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
@@ -112,12 +126,14 @@ export type CreateDepositResponse = {
         amount: string;
         mint: string;
         createDestinationAccount?: boolean | undefined;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
         kind: "Tep74";
         master: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     };
@@ -156,6 +172,7 @@ export type CreateWithdrawalBody = {
     kind: "Native";
     amount: string;
     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
@@ -163,24 +180,28 @@ export type CreateWithdrawalBody = {
     contract: string;
     amount: string;
     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
     kind: "Trc10";
     tokenId: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
     kind: "Trc20";
     contract: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
     kind: "Asa";
     assetId: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
@@ -188,6 +209,7 @@ export type CreateWithdrawalBody = {
     issuer: string;
     assetCode: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
@@ -195,12 +217,14 @@ export type CreateWithdrawalBody = {
     amount: string;
     mint: string;
     createDestinationAccount?: boolean | undefined;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 } | {
     kind: "Tep74";
     master: string;
     amount: string;
+    externalId?: string | undefined;
     walletId: string;
     otp?: string | undefined;
 };
@@ -227,6 +251,7 @@ export type CreateWithdrawalResponse = {
         kind: "Native";
         amount: string;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
@@ -234,24 +259,28 @@ export type CreateWithdrawalResponse = {
         contract: string;
         amount: string;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
         kind: "Trc10";
         tokenId: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
         kind: "Trc20";
         contract: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
         kind: "Asa";
         assetId: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
@@ -259,6 +288,7 @@ export type CreateWithdrawalResponse = {
         issuer: string;
         assetCode: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
@@ -266,12 +296,14 @@ export type CreateWithdrawalResponse = {
         amount: string;
         mint: string;
         createDestinationAccount?: boolean | undefined;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     } | {
         kind: "Tep74";
         master: string;
         amount: string;
+        externalId?: string | undefined;
         walletId: string;
         otp?: string | undefined;
     };

--- a/packages/sdk/generated/policies/types.ts
+++ b/packages/sdk/generated/policies/types.ts
@@ -248,38 +248,45 @@ export type CreateApprovalDecisionResponse = {
                 amount: string;
                 memo?: string | undefined;
                 priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Erc20";
                 contract: string;
                 to: string;
                 amount: string;
                 priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Erc721";
                 contract: string;
                 to: string;
                 tokenId: string;
                 priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Trc10";
                 tokenId: string;
                 to: string;
                 amount: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Trc20";
                 contract: string;
                 to: string;
                 amount: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Trc721";
                 contract: string;
                 to: string;
                 tokenId: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Asa";
                 assetId: string;
                 to: string;
                 amount: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Sep41";
                 issuer: string;
@@ -287,18 +294,21 @@ export type CreateApprovalDecisionResponse = {
                 to: string;
                 amount: string;
                 memo?: string | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Spl" | "Spl2022";
                 to: string;
                 amount: string;
                 mint: string;
                 createDestinationAccount?: boolean | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Tep74";
                 to: string;
                 master: string;
                 amount: string;
                 memo?: string | undefined;
+                externalId?: string | undefined;
             };
             metadata: {
                 asset: {
@@ -319,6 +329,7 @@ export type CreateApprovalDecisionResponse = {
             dateBroadcasted?: string | undefined;
             dateConfirmed?: string | undefined;
             approvalId?: string | undefined;
+            externalId?: string | undefined;
         } | undefined;
         transactionRequest?: {
             id: string;
@@ -332,6 +343,7 @@ export type CreateApprovalDecisionResponse = {
             requestBody: {
                 kind: "Transaction";
                 transaction: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Evm";
                 to?: string | undefined;
@@ -339,6 +351,7 @@ export type CreateApprovalDecisionResponse = {
                 data?: string | undefined;
                 nonce?: (number | string | string) | undefined;
                 gasLimit?: (string | string) | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Eip1559";
                 to?: string | undefined;
@@ -348,6 +361,7 @@ export type CreateApprovalDecisionResponse = {
                 gasLimit?: (string | string) | undefined;
                 maxFeePerGas?: (string | string) | undefined;
                 maxPriorityFeePerGas?: (string | string) | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "EvmLegacy";
                 to?: string | undefined;
@@ -356,9 +370,11 @@ export type CreateApprovalDecisionResponse = {
                 nonce?: (number | string | string) | undefined;
                 gasLimit?: (string | string) | undefined;
                 gasPrice?: (string | string) | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Psbt";
                 psbt: string;
+                externalId?: string | undefined;
             };
             status: "Pending" | "Executing" | "Broadcasted" | "Confirmed" | "Failed" | "Rejected";
             reason?: string | undefined;
@@ -369,6 +385,7 @@ export type CreateApprovalDecisionResponse = {
             datePolicyResolved?: string | undefined;
             dateBroadcasted?: string | undefined;
             dateConfirmed?: string | undefined;
+            externalId?: string | undefined;
         } | undefined;
         signatureRequest?: {
             id: string;
@@ -382,12 +399,15 @@ export type CreateApprovalDecisionResponse = {
             requestBody: {
                 kind: "Hash";
                 hash: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Message";
                 message: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Transaction";
                 transaction: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Eip712";
                 types: {
@@ -406,9 +426,11 @@ export type CreateApprovalDecisionResponse = {
                 message: {
                     [x: string]: unknown;
                 };
+                externalId?: string | undefined;
             } | {
                 kind: "Psbt";
                 psbt: string;
+                externalId?: string | undefined;
             };
             status: "Pending" | "Executing" | "Signed" | "Confirmed" | "Failed" | "Rejected";
             reason?: string | undefined;
@@ -432,6 +454,7 @@ export type CreateApprovalDecisionResponse = {
             datePolicyResolved?: string | undefined;
             dateSigned?: string | undefined;
             dateConfirmed?: string | undefined;
+            externalId?: string | undefined;
         } | undefined;
     } | {
         kind: "Wallets:IncomingTransaction";
@@ -1548,38 +1571,45 @@ export type GetApprovalResponse = {
                 amount: string;
                 memo?: string | undefined;
                 priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Erc20";
                 contract: string;
                 to: string;
                 amount: string;
                 priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Erc721";
                 contract: string;
                 to: string;
                 tokenId: string;
                 priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Trc10";
                 tokenId: string;
                 to: string;
                 amount: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Trc20";
                 contract: string;
                 to: string;
                 amount: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Trc721";
                 contract: string;
                 to: string;
                 tokenId: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Asa";
                 assetId: string;
                 to: string;
                 amount: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Sep41";
                 issuer: string;
@@ -1587,18 +1617,21 @@ export type GetApprovalResponse = {
                 to: string;
                 amount: string;
                 memo?: string | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Spl" | "Spl2022";
                 to: string;
                 amount: string;
                 mint: string;
                 createDestinationAccount?: boolean | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Tep74";
                 to: string;
                 master: string;
                 amount: string;
                 memo?: string | undefined;
+                externalId?: string | undefined;
             };
             metadata: {
                 asset: {
@@ -1619,6 +1652,7 @@ export type GetApprovalResponse = {
             dateBroadcasted?: string | undefined;
             dateConfirmed?: string | undefined;
             approvalId?: string | undefined;
+            externalId?: string | undefined;
         } | undefined;
         transactionRequest?: {
             id: string;
@@ -1632,6 +1666,7 @@ export type GetApprovalResponse = {
             requestBody: {
                 kind: "Transaction";
                 transaction: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Evm";
                 to?: string | undefined;
@@ -1639,6 +1674,7 @@ export type GetApprovalResponse = {
                 data?: string | undefined;
                 nonce?: (number | string | string) | undefined;
                 gasLimit?: (string | string) | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Eip1559";
                 to?: string | undefined;
@@ -1648,6 +1684,7 @@ export type GetApprovalResponse = {
                 gasLimit?: (string | string) | undefined;
                 maxFeePerGas?: (string | string) | undefined;
                 maxPriorityFeePerGas?: (string | string) | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "EvmLegacy";
                 to?: string | undefined;
@@ -1656,9 +1693,11 @@ export type GetApprovalResponse = {
                 nonce?: (number | string | string) | undefined;
                 gasLimit?: (string | string) | undefined;
                 gasPrice?: (string | string) | undefined;
+                externalId?: string | undefined;
             } | {
                 kind: "Psbt";
                 psbt: string;
+                externalId?: string | undefined;
             };
             status: "Pending" | "Executing" | "Broadcasted" | "Confirmed" | "Failed" | "Rejected";
             reason?: string | undefined;
@@ -1669,6 +1708,7 @@ export type GetApprovalResponse = {
             datePolicyResolved?: string | undefined;
             dateBroadcasted?: string | undefined;
             dateConfirmed?: string | undefined;
+            externalId?: string | undefined;
         } | undefined;
         signatureRequest?: {
             id: string;
@@ -1682,12 +1722,15 @@ export type GetApprovalResponse = {
             requestBody: {
                 kind: "Hash";
                 hash: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Message";
                 message: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Transaction";
                 transaction: string;
+                externalId?: string | undefined;
             } | {
                 kind: "Eip712";
                 types: {
@@ -1706,9 +1749,11 @@ export type GetApprovalResponse = {
                 message: {
                     [x: string]: unknown;
                 };
+                externalId?: string | undefined;
             } | {
                 kind: "Psbt";
                 psbt: string;
+                externalId?: string | undefined;
             };
             status: "Pending" | "Executing" | "Signed" | "Confirmed" | "Failed" | "Rejected";
             reason?: string | undefined;
@@ -1732,6 +1777,7 @@ export type GetApprovalResponse = {
             datePolicyResolved?: string | undefined;
             dateSigned?: string | undefined;
             dateConfirmed?: string | undefined;
+            externalId?: string | undefined;
         } | undefined;
     } | {
         kind: "Wallets:IncomingTransaction";
@@ -2892,38 +2938,45 @@ export type ListApprovalsResponse = {
                     amount: string;
                     memo?: string | undefined;
                     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Erc20";
                     contract: string;
                     to: string;
                     amount: string;
                     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Erc721";
                     contract: string;
                     to: string;
                     tokenId: string;
                     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Trc10";
                     tokenId: string;
                     to: string;
                     amount: string;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Trc20";
                     contract: string;
                     to: string;
                     amount: string;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Trc721";
                     contract: string;
                     to: string;
                     tokenId: string;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Asa";
                     assetId: string;
                     to: string;
                     amount: string;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Sep41";
                     issuer: string;
@@ -2931,18 +2984,21 @@ export type ListApprovalsResponse = {
                     to: string;
                     amount: string;
                     memo?: string | undefined;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Spl" | "Spl2022";
                     to: string;
                     amount: string;
                     mint: string;
                     createDestinationAccount?: boolean | undefined;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Tep74";
                     to: string;
                     master: string;
                     amount: string;
                     memo?: string | undefined;
+                    externalId?: string | undefined;
                 };
                 metadata: {
                     asset: {
@@ -2963,6 +3019,7 @@ export type ListApprovalsResponse = {
                 dateBroadcasted?: string | undefined;
                 dateConfirmed?: string | undefined;
                 approvalId?: string | undefined;
+                externalId?: string | undefined;
             } | undefined;
             transactionRequest?: {
                 id: string;
@@ -2976,6 +3033,7 @@ export type ListApprovalsResponse = {
                 requestBody: {
                     kind: "Transaction";
                     transaction: string;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Evm";
                     to?: string | undefined;
@@ -2983,6 +3041,7 @@ export type ListApprovalsResponse = {
                     data?: string | undefined;
                     nonce?: (number | string | string) | undefined;
                     gasLimit?: (string | string) | undefined;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Eip1559";
                     to?: string | undefined;
@@ -2992,6 +3051,7 @@ export type ListApprovalsResponse = {
                     gasLimit?: (string | string) | undefined;
                     maxFeePerGas?: (string | string) | undefined;
                     maxPriorityFeePerGas?: (string | string) | undefined;
+                    externalId?: string | undefined;
                 } | {
                     kind: "EvmLegacy";
                     to?: string | undefined;
@@ -3000,9 +3060,11 @@ export type ListApprovalsResponse = {
                     nonce?: (number | string | string) | undefined;
                     gasLimit?: (string | string) | undefined;
                     gasPrice?: (string | string) | undefined;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Psbt";
                     psbt: string;
+                    externalId?: string | undefined;
                 };
                 status: "Pending" | "Executing" | "Broadcasted" | "Confirmed" | "Failed" | "Rejected";
                 reason?: string | undefined;
@@ -3013,6 +3075,7 @@ export type ListApprovalsResponse = {
                 datePolicyResolved?: string | undefined;
                 dateBroadcasted?: string | undefined;
                 dateConfirmed?: string | undefined;
+                externalId?: string | undefined;
             } | undefined;
             signatureRequest?: {
                 id: string;
@@ -3026,12 +3089,15 @@ export type ListApprovalsResponse = {
                 requestBody: {
                     kind: "Hash";
                     hash: string;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Message";
                     message: string;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Transaction";
                     transaction: string;
+                    externalId?: string | undefined;
                 } | {
                     kind: "Eip712";
                     types: {
@@ -3050,9 +3116,11 @@ export type ListApprovalsResponse = {
                     message: {
                         [x: string]: unknown;
                     };
+                    externalId?: string | undefined;
                 } | {
                     kind: "Psbt";
                     psbt: string;
+                    externalId?: string | undefined;
                 };
                 status: "Pending" | "Executing" | "Signed" | "Confirmed" | "Failed" | "Rejected";
                 reason?: string | undefined;
@@ -3076,6 +3144,7 @@ export type ListApprovalsResponse = {
                 datePolicyResolved?: string | undefined;
                 dateSigned?: string | undefined;
                 dateConfirmed?: string | undefined;
+                externalId?: string | undefined;
             } | undefined;
         } | {
             kind: "Wallets:IncomingTransaction";

--- a/packages/sdk/generated/wallets/types.ts
+++ b/packages/sdk/generated/wallets/types.ts
@@ -1,6 +1,7 @@
 export type BroadcastTransactionBody = {
     kind: "Transaction";
     transaction: string;
+    externalId?: string | undefined;
 } | {
     kind: "Evm";
     to?: string | undefined;
@@ -8,6 +9,7 @@ export type BroadcastTransactionBody = {
     data?: string | undefined;
     nonce?: (number | string | string) | undefined;
     gasLimit?: (string | string) | undefined;
+    externalId?: string | undefined;
 } | {
     kind: "Eip1559";
     to?: string | undefined;
@@ -17,6 +19,7 @@ export type BroadcastTransactionBody = {
     gasLimit?: (string | string) | undefined;
     maxFeePerGas?: (string | string) | undefined;
     maxPriorityFeePerGas?: (string | string) | undefined;
+    externalId?: string | undefined;
 } | {
     kind: "EvmLegacy";
     to?: string | undefined;
@@ -25,9 +28,11 @@ export type BroadcastTransactionBody = {
     nonce?: (number | string | string) | undefined;
     gasLimit?: (string | string) | undefined;
     gasPrice?: (string | string) | undefined;
+    externalId?: string | undefined;
 } | {
     kind: "Psbt";
     psbt: string;
+    externalId?: string | undefined;
 };
 
 export type BroadcastTransactionParams = {
@@ -46,6 +51,7 @@ export type BroadcastTransactionResponse = {
     requestBody: {
         kind: "Transaction";
         transaction: string;
+        externalId?: string | undefined;
     } | {
         kind: "Evm";
         to?: string | undefined;
@@ -53,6 +59,7 @@ export type BroadcastTransactionResponse = {
         data?: string | undefined;
         nonce?: (number | string | string) | undefined;
         gasLimit?: (string | string) | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Eip1559";
         to?: string | undefined;
@@ -62,6 +69,7 @@ export type BroadcastTransactionResponse = {
         gasLimit?: (string | string) | undefined;
         maxFeePerGas?: (string | string) | undefined;
         maxPriorityFeePerGas?: (string | string) | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "EvmLegacy";
         to?: string | undefined;
@@ -70,9 +78,11 @@ export type BroadcastTransactionResponse = {
         nonce?: (number | string | string) | undefined;
         gasLimit?: (string | string) | undefined;
         gasPrice?: (string | string) | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Psbt";
         psbt: string;
+        externalId?: string | undefined;
     };
     status: "Pending" | "Executing" | "Broadcasted" | "Confirmed" | "Failed" | "Rejected";
     reason?: string | undefined;
@@ -83,6 +93,7 @@ export type BroadcastTransactionResponse = {
     datePolicyResolved?: string | undefined;
     dateBroadcasted?: string | undefined;
     dateConfirmed?: string | undefined;
+    externalId?: string | undefined;
 };
 
 export type BroadcastTransactionRequest = BroadcastTransactionParams & { body: BroadcastTransactionBody }
@@ -165,12 +176,15 @@ export type ExportWalletRequest = ExportWalletParams & { body: ExportWalletBody 
 export type GenerateSignatureBody = {
     kind: "Hash";
     hash: string;
+    externalId?: string | undefined;
 } | {
     kind: "Message";
     message: string;
+    externalId?: string | undefined;
 } | {
     kind: "Transaction";
     transaction: string;
+    externalId?: string | undefined;
 } | {
     kind: "Eip712";
     types: {
@@ -189,9 +203,11 @@ export type GenerateSignatureBody = {
     message: {
         [x: string]: unknown;
     };
+    externalId?: string | undefined;
 } | {
     kind: "Psbt";
     psbt: string;
+    externalId?: string | undefined;
 };
 
 export type GenerateSignatureParams = {
@@ -210,12 +226,15 @@ export type GenerateSignatureResponse = {
     requestBody: {
         kind: "Hash";
         hash: string;
+        externalId?: string | undefined;
     } | {
         kind: "Message";
         message: string;
+        externalId?: string | undefined;
     } | {
         kind: "Transaction";
         transaction: string;
+        externalId?: string | undefined;
     } | {
         kind: "Eip712";
         types: {
@@ -234,9 +253,11 @@ export type GenerateSignatureResponse = {
         message: {
             [x: string]: unknown;
         };
+        externalId?: string | undefined;
     } | {
         kind: "Psbt";
         psbt: string;
+        externalId?: string | undefined;
     };
     status: "Pending" | "Executing" | "Signed" | "Confirmed" | "Failed" | "Rejected";
     reason?: string | undefined;
@@ -260,6 +281,7 @@ export type GenerateSignatureResponse = {
     datePolicyResolved?: string | undefined;
     dateSigned?: string | undefined;
     dateConfirmed?: string | undefined;
+    externalId?: string | undefined;
 };
 
 export type GenerateSignatureRequest = GenerateSignatureParams & { body: GenerateSignatureBody }
@@ -281,12 +303,15 @@ export type GetSignatureResponse = {
     requestBody: {
         kind: "Hash";
         hash: string;
+        externalId?: string | undefined;
     } | {
         kind: "Message";
         message: string;
+        externalId?: string | undefined;
     } | {
         kind: "Transaction";
         transaction: string;
+        externalId?: string | undefined;
     } | {
         kind: "Eip712";
         types: {
@@ -305,9 +330,11 @@ export type GetSignatureResponse = {
         message: {
             [x: string]: unknown;
         };
+        externalId?: string | undefined;
     } | {
         kind: "Psbt";
         psbt: string;
+        externalId?: string | undefined;
     };
     status: "Pending" | "Executing" | "Signed" | "Confirmed" | "Failed" | "Rejected";
     reason?: string | undefined;
@@ -331,6 +358,7 @@ export type GetSignatureResponse = {
     datePolicyResolved?: string | undefined;
     dateSigned?: string | undefined;
     dateConfirmed?: string | undefined;
+    externalId?: string | undefined;
 };
 
 export type GetSignatureRequest = GetSignatureParams
@@ -352,6 +380,7 @@ export type GetTransactionResponse = {
     requestBody: {
         kind: "Transaction";
         transaction: string;
+        externalId?: string | undefined;
     } | {
         kind: "Evm";
         to?: string | undefined;
@@ -359,6 +388,7 @@ export type GetTransactionResponse = {
         data?: string | undefined;
         nonce?: (number | string | string) | undefined;
         gasLimit?: (string | string) | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Eip1559";
         to?: string | undefined;
@@ -368,6 +398,7 @@ export type GetTransactionResponse = {
         gasLimit?: (string | string) | undefined;
         maxFeePerGas?: (string | string) | undefined;
         maxPriorityFeePerGas?: (string | string) | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "EvmLegacy";
         to?: string | undefined;
@@ -376,9 +407,11 @@ export type GetTransactionResponse = {
         nonce?: (number | string | string) | undefined;
         gasLimit?: (string | string) | undefined;
         gasPrice?: (string | string) | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Psbt";
         psbt: string;
+        externalId?: string | undefined;
     };
     status: "Pending" | "Executing" | "Broadcasted" | "Confirmed" | "Failed" | "Rejected";
     reason?: string | undefined;
@@ -389,6 +422,7 @@ export type GetTransactionResponse = {
     datePolicyResolved?: string | undefined;
     dateBroadcasted?: string | undefined;
     dateConfirmed?: string | undefined;
+    externalId?: string | undefined;
 };
 
 export type GetTransactionRequest = GetTransactionParams
@@ -413,38 +447,45 @@ export type GetTransferResponse = {
         amount: string;
         memo?: string | undefined;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Erc20";
         contract: string;
         to: string;
         amount: string;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Erc721";
         contract: string;
         to: string;
         tokenId: string;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Trc10";
         tokenId: string;
         to: string;
         amount: string;
+        externalId?: string | undefined;
     } | {
         kind: "Trc20";
         contract: string;
         to: string;
         amount: string;
+        externalId?: string | undefined;
     } | {
         kind: "Trc721";
         contract: string;
         to: string;
         tokenId: string;
+        externalId?: string | undefined;
     } | {
         kind: "Asa";
         assetId: string;
         to: string;
         amount: string;
+        externalId?: string | undefined;
     } | {
         kind: "Sep41";
         issuer: string;
@@ -452,18 +493,21 @@ export type GetTransferResponse = {
         to: string;
         amount: string;
         memo?: string | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Spl" | "Spl2022";
         to: string;
         amount: string;
         mint: string;
         createDestinationAccount?: boolean | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Tep74";
         to: string;
         master: string;
         amount: string;
         memo?: string | undefined;
+        externalId?: string | undefined;
     };
     metadata: {
         asset: {
@@ -484,6 +528,7 @@ export type GetTransferResponse = {
     dateBroadcasted?: string | undefined;
     dateConfirmed?: string | undefined;
     approvalId?: string | undefined;
+    externalId?: string | undefined;
 };
 
 export type GetTransferRequest = GetTransferParams
@@ -1030,12 +1075,15 @@ export type ListSignaturesResponse = {
         requestBody: {
             kind: "Hash";
             hash: string;
+            externalId?: string | undefined;
         } | {
             kind: "Message";
             message: string;
+            externalId?: string | undefined;
         } | {
             kind: "Transaction";
             transaction: string;
+            externalId?: string | undefined;
         } | {
             kind: "Eip712";
             types: {
@@ -1054,9 +1102,11 @@ export type ListSignaturesResponse = {
             message: {
                 [x: string]: unknown;
             };
+            externalId?: string | undefined;
         } | {
             kind: "Psbt";
             psbt: string;
+            externalId?: string | undefined;
         };
         status: "Pending" | "Executing" | "Signed" | "Confirmed" | "Failed" | "Rejected";
         reason?: string | undefined;
@@ -1080,6 +1130,7 @@ export type ListSignaturesResponse = {
         datePolicyResolved?: string | undefined;
         dateSigned?: string | undefined;
         dateConfirmed?: string | undefined;
+        externalId?: string | undefined;
     }[];
     nextPageToken?: string | undefined;
 };
@@ -1109,6 +1160,7 @@ export type ListTransactionsResponse = {
         requestBody: {
             kind: "Transaction";
             transaction: string;
+            externalId?: string | undefined;
         } | {
             kind: "Evm";
             to?: string | undefined;
@@ -1116,6 +1168,7 @@ export type ListTransactionsResponse = {
             data?: string | undefined;
             nonce?: (number | string | string) | undefined;
             gasLimit?: (string | string) | undefined;
+            externalId?: string | undefined;
         } | {
             kind: "Eip1559";
             to?: string | undefined;
@@ -1125,6 +1178,7 @@ export type ListTransactionsResponse = {
             gasLimit?: (string | string) | undefined;
             maxFeePerGas?: (string | string) | undefined;
             maxPriorityFeePerGas?: (string | string) | undefined;
+            externalId?: string | undefined;
         } | {
             kind: "EvmLegacy";
             to?: string | undefined;
@@ -1133,9 +1187,11 @@ export type ListTransactionsResponse = {
             nonce?: (number | string | string) | undefined;
             gasLimit?: (string | string) | undefined;
             gasPrice?: (string | string) | undefined;
+            externalId?: string | undefined;
         } | {
             kind: "Psbt";
             psbt: string;
+            externalId?: string | undefined;
         };
         status: "Pending" | "Executing" | "Broadcasted" | "Confirmed" | "Failed" | "Rejected";
         reason?: string | undefined;
@@ -1146,6 +1202,7 @@ export type ListTransactionsResponse = {
         datePolicyResolved?: string | undefined;
         dateBroadcasted?: string | undefined;
         dateConfirmed?: string | undefined;
+        externalId?: string | undefined;
     }[];
     nextPageToken?: string | undefined;
 };
@@ -1178,38 +1235,45 @@ export type ListTransfersResponse = {
             amount: string;
             memo?: string | undefined;
             priority?: ("Slow" | "Standard" | "Fast") | undefined;
+            externalId?: string | undefined;
         } | {
             kind: "Erc20";
             contract: string;
             to: string;
             amount: string;
             priority?: ("Slow" | "Standard" | "Fast") | undefined;
+            externalId?: string | undefined;
         } | {
             kind: "Erc721";
             contract: string;
             to: string;
             tokenId: string;
             priority?: ("Slow" | "Standard" | "Fast") | undefined;
+            externalId?: string | undefined;
         } | {
             kind: "Trc10";
             tokenId: string;
             to: string;
             amount: string;
+            externalId?: string | undefined;
         } | {
             kind: "Trc20";
             contract: string;
             to: string;
             amount: string;
+            externalId?: string | undefined;
         } | {
             kind: "Trc721";
             contract: string;
             to: string;
             tokenId: string;
+            externalId?: string | undefined;
         } | {
             kind: "Asa";
             assetId: string;
             to: string;
             amount: string;
+            externalId?: string | undefined;
         } | {
             kind: "Sep41";
             issuer: string;
@@ -1217,18 +1281,21 @@ export type ListTransfersResponse = {
             to: string;
             amount: string;
             memo?: string | undefined;
+            externalId?: string | undefined;
         } | {
             kind: "Spl" | "Spl2022";
             to: string;
             amount: string;
             mint: string;
             createDestinationAccount?: boolean | undefined;
+            externalId?: string | undefined;
         } | {
             kind: "Tep74";
             to: string;
             master: string;
             amount: string;
             memo?: string | undefined;
+            externalId?: string | undefined;
         };
         metadata: {
             asset: {
@@ -1249,6 +1316,7 @@ export type ListTransfersResponse = {
         dateBroadcasted?: string | undefined;
         dateConfirmed?: string | undefined;
         approvalId?: string | undefined;
+        externalId?: string | undefined;
     }[];
     nextPageToken?: string | undefined;
 };
@@ -1305,38 +1373,45 @@ export type TransferAssetBody = {
     amount: string;
     memo?: string | undefined;
     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+    externalId?: string | undefined;
 } | {
     kind: "Erc20";
     contract: string;
     to: string;
     amount: string;
     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+    externalId?: string | undefined;
 } | {
     kind: "Erc721";
     contract: string;
     to: string;
     tokenId: string;
     priority?: ("Slow" | "Standard" | "Fast") | undefined;
+    externalId?: string | undefined;
 } | {
     kind: "Trc10";
     tokenId: string;
     to: string;
     amount: string;
+    externalId?: string | undefined;
 } | {
     kind: "Trc20";
     contract: string;
     to: string;
     amount: string;
+    externalId?: string | undefined;
 } | {
     kind: "Trc721";
     contract: string;
     to: string;
     tokenId: string;
+    externalId?: string | undefined;
 } | {
     kind: "Asa";
     assetId: string;
     to: string;
     amount: string;
+    externalId?: string | undefined;
 } | {
     kind: "Sep41";
     issuer: string;
@@ -1344,18 +1419,21 @@ export type TransferAssetBody = {
     to: string;
     amount: string;
     memo?: string | undefined;
+    externalId?: string | undefined;
 } | {
     kind: "Spl" | "Spl2022";
     to: string;
     amount: string;
     mint: string;
     createDestinationAccount?: boolean | undefined;
+    externalId?: string | undefined;
 } | {
     kind: "Tep74";
     to: string;
     master: string;
     amount: string;
     memo?: string | undefined;
+    externalId?: string | undefined;
 };
 
 export type TransferAssetParams = {
@@ -1377,38 +1455,45 @@ export type TransferAssetResponse = {
         amount: string;
         memo?: string | undefined;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Erc20";
         contract: string;
         to: string;
         amount: string;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Erc721";
         contract: string;
         to: string;
         tokenId: string;
         priority?: ("Slow" | "Standard" | "Fast") | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Trc10";
         tokenId: string;
         to: string;
         amount: string;
+        externalId?: string | undefined;
     } | {
         kind: "Trc20";
         contract: string;
         to: string;
         amount: string;
+        externalId?: string | undefined;
     } | {
         kind: "Trc721";
         contract: string;
         to: string;
         tokenId: string;
+        externalId?: string | undefined;
     } | {
         kind: "Asa";
         assetId: string;
         to: string;
         amount: string;
+        externalId?: string | undefined;
     } | {
         kind: "Sep41";
         issuer: string;
@@ -1416,18 +1501,21 @@ export type TransferAssetResponse = {
         to: string;
         amount: string;
         memo?: string | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Spl" | "Spl2022";
         to: string;
         amount: string;
         mint: string;
         createDestinationAccount?: boolean | undefined;
+        externalId?: string | undefined;
     } | {
         kind: "Tep74";
         to: string;
         master: string;
         amount: string;
         memo?: string | undefined;
+        externalId?: string | undefined;
     };
     metadata: {
         asset: {
@@ -1448,6 +1536,7 @@ export type TransferAssetResponse = {
     dateBroadcasted?: string | undefined;
     dateConfirmed?: string | undefined;
     approvalId?: string | undefined;
+    externalId?: string | undefined;
 };
 
 export type TransferAssetRequest = TransferAssetParams & { body: TransferAssetBody }


### PR DESCRIPTION
Adds `externalId` to 3 wallet endpoints:
- Transfer Asset
- Broadcast Transaction
- Generate Signature

see [idempotency doc](https://docs.dfns.co/d/advanced-topics/api-idempotency) for more details