### PR TITLE
fix: generic ton message signing

### DIFF
--- a/examples/libs/ton/basic-tx/README.md
+++ b/examples/libs/ton/basic-tx/README.md
@@ -37,14 +37,14 @@ Copy `.env.example` to a new file `.env` and set the following values,
 
 ## Explanation
 
-The program runs on the TON testnet network. To execute the code, you will need a testnet wallet containing some TON. The program is designed to send 1 TON from your wallet to a specific address.
+The program runs on the TON testnet. It uses the [wallet v5 contract](https://docs.ton.org/participate/wallets/contracts#wallet-v5), but you can use any TON wallet contract. To execute the code, you will need to fund the wallet with some testnet tokens.
 
 ```shell
 > ts-node main.ts
 
-ton sender address: EQCX6Es8MH_KGbsHJ7oTDEDqNgR3xnLCHU0H36UP0Ux7G4FM
-native transfer cell broadcasted
-transaction hash retrieved: 168de26e7fbca25cade6801f4b71c5a8e9566f4cef1ddb216df809adfca2c229
+wallet address:  0QAXh03SUULqKi-6875HYA3SPJB5APqX8R0tGynQUEXKKmGg
+current balance:  2000000000n
+balance after transfer:  1994129596n
 ```
 
-This is a [transaction](https://testnet.tonscan.org/address/EQCX6Es8MH_KGbsHJ7oTDEDqNgR3xnLCHU0H36UP0Ux7G4FM) for example.
+This is the transfer [transaction](https://testnet.tonscan.org/tx/jsySLCEPmZpWxyeXGSdGcWhkGKxfSbF-XP1n5omY4nI=).

--- a/examples/libs/ton/basic-tx/package-lock.json
+++ b/examples/libs/ton/basic-tx/package-lock.json
@@ -12,6 +12,7 @@
         "@dfns/sdk": "file:../../../packages/sdk",
         "@dfns/sdk-keysigner": "file:../../../packages/sdk-keysigner",
         "@orbs-network/ton-access": "2.3.3",
+        "@ton/ton": "15.1.0",
         "dotenv": "16.1.4"
       },
       "devDependencies": {
@@ -77,6 +78,54 @@
         "isomorphic-fetch": "^3.0.0"
       }
     },
+    "node_modules/@ton/core": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.59.0.tgz",
+      "integrity": "sha512-LSIkGst7BoY7fMWshejzcH0UJnoW21JGlRrW0ch+6A7Xb/7EuekxgdKym7fHxcry6OIf6FoeFg97lJ960N/Ghg==",
+      "peer": true,
+      "dependencies": {
+        "symbol.inspect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@ton/crypto": ">=3.2.0"
+      }
+    },
+    "node_modules/@ton/crypto": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.3.0.tgz",
+      "integrity": "sha512-/A6CYGgA/H36OZ9BbTaGerKtzWp50rg67ZCH2oIjV1NcrBaCK9Z343M+CxedvM7Haf3f/Ee9EhxyeTp0GKMUpA==",
+      "peer": true,
+      "dependencies": {
+        "@ton/crypto-primitives": "2.1.0",
+        "jssha": "3.2.0",
+        "tweetnacl": "1.0.3"
+      }
+    },
+    "node_modules/@ton/crypto-primitives": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.1.0.tgz",
+      "integrity": "sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==",
+      "peer": true,
+      "dependencies": {
+        "jssha": "3.2.0"
+      }
+    },
+    "node_modules/@ton/ton": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@ton/ton/-/ton-15.1.0.tgz",
+      "integrity": "sha512-almetcfTu7jLjcNcEEPB7wAc8yl90ES1M//sOr1QE+kv7RbmEvMkaPSc7kFxzs10qrjIPKxlodBJlMSWP5LuVQ==",
+      "dependencies": {
+        "axios": "^1.6.7",
+        "dataloader": "^2.0.0",
+        "symbol.inspect": "1.0.1",
+        "teslabot": "^1.3.0",
+        "zod": "^3.21.4"
+      },
+      "peerDependencies": {
+        "@ton/core": ">=0.59.0",
+        "@ton/crypto": ">=3.2.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
@@ -130,10 +179,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -153,6 +241,38 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
@@ -162,10 +282,38 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "node_modules/jssha": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.2.0.tgz",
+      "integrity": "sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -185,6 +333,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/symbol.inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol.inspect/-/symbol.inspect-1.0.1.tgz",
+      "integrity": "sha512-YQSL4duoHmLhsTD1Pw8RW6TZ5MaTX5rXJnqacJottr2P2LZBF/Yvrc3ku4NUpMOm8aM0KOCqM+UAkMA5HWQCzQ=="
+    },
+    "node_modules/teslabot": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/teslabot/-/teslabot-1.5.0.tgz",
+      "integrity": "sha512-e2MmELhCgrgZEGo7PQu/6bmYG36IDH+YrBI1iGm6jovXkeDIGa3pZ2WSqRjzkuw2vt1EqfkZoV5GpXgqL8QJVg=="
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -232,6 +395,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "5.4.2",
@@ -282,6 +451,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/examples/libs/ton/basic-tx/package.json
+++ b/examples/libs/ton/basic-tx/package.json
@@ -7,6 +7,7 @@
     "@dfns/sdk": "file:../../../packages/sdk",
     "@dfns/sdk-keysigner": "file:../../../packages/sdk-keysigner",
     "@orbs-network/ton-access": "2.3.3",
+    "@ton/ton": "15.1.0",
     "dotenv": "16.1.4"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@solana/web3.js": "^1.0.0",
         "@stellar/stellar-sdk": "^11.0.0",
         "@taquito/taquito": "^17.0.0",
-        "@ton/ton": "13.11.2",
+        "@ton/ton": "^15.0.0",
         "@vechain/connex-driver": "2.0.12",
         "algosdk": "^2.0.0",
         "bitcoinjs-lib": "^6.0.0",
@@ -6981,9 +6981,9 @@
       }
     },
     "node_modules/@ton/core": {
-      "version": "0.56.3",
-      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.56.3.tgz",
-      "integrity": "sha512-HVkalfqw8zqLLPehtq0CNhu5KjVzc7IrbDwDHPjGoOSXmnqSobiWj8a5F+YuWnZnEbQKtrnMGNOOjVw4LG37rg==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.59.0.tgz",
+      "integrity": "sha512-LSIkGst7BoY7fMWshejzcH0UJnoW21JGlRrW0ch+6A7Xb/7EuekxgdKym7fHxcry6OIf6FoeFg97lJ960N/Ghg==",
       "peer": true,
       "dependencies": {
         "symbol.inspect": "1.0.1"
@@ -6993,29 +6993,29 @@
       }
     },
     "node_modules/@ton/crypto": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.2.0.tgz",
-      "integrity": "sha512-50RkwReEuV2FkxSZ8ht/x9+n0ZGtwRKGsJ0ay4I/HFhkYVG/awIIBQeH0W4j8d5lADdO5h01UtX8PJ8AjiejjA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.3.0.tgz",
+      "integrity": "sha512-/A6CYGgA/H36OZ9BbTaGerKtzWp50rg67ZCH2oIjV1NcrBaCK9Z343M+CxedvM7Haf3f/Ee9EhxyeTp0GKMUpA==",
       "peer": true,
       "dependencies": {
-        "@ton/crypto-primitives": "2.0.0",
+        "@ton/crypto-primitives": "2.1.0",
         "jssha": "3.2.0",
         "tweetnacl": "1.0.3"
       }
     },
     "node_modules/@ton/crypto-primitives": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.0.0.tgz",
-      "integrity": "sha512-wttiNClmGbI6Dfy/8oyNnsIV0b/qYkCJz4Gn4eP62lJZzMtVQ94Ko7nikDX1EfYHkLI1xpOitWpW+8ZuG6XtDg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.1.0.tgz",
+      "integrity": "sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==",
       "peer": true,
       "dependencies": {
         "jssha": "3.2.0"
       }
     },
     "node_modules/@ton/ton": {
-      "version": "13.11.2",
-      "resolved": "https://registry.npmjs.org/@ton/ton/-/ton-13.11.2.tgz",
-      "integrity": "sha512-EPqW+ZTe0MmfqguJEIGMuAqTAFRKMEce95HlDx8h6CGn2y3jiMgV1/oO+WpDIOiX+1wnTu+xtajk8JTWr8nKRQ==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@ton/ton/-/ton-15.1.0.tgz",
+      "integrity": "sha512-almetcfTu7jLjcNcEEPB7wAc8yl90ES1M//sOr1QE+kv7RbmEvMkaPSc7kFxzs10qrjIPKxlodBJlMSWP5LuVQ==",
       "peer": true,
       "dependencies": {
         "axios": "^1.6.7",
@@ -7025,7 +7025,7 @@
         "zod": "^3.21.4"
       },
       "peerDependencies": {
-        "@ton/core": ">=0.56.0",
+        "@ton/core": ">=0.59.0",
         "@ton/crypto": ">=3.2.0"
       }
     },
@@ -15912,7 +15912,7 @@
       "name": "@dfns/lib-ton",
       "version": "0.4.3",
       "peerDependencies": {
-        "@ton/ton": "13.11.2"
+        "@ton/ton": "^15.0.0"
       }
     },
     "packages/lib-tron": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@solana/web3.js": "^1.0.0",
     "@stellar/stellar-sdk": "^11.0.0",
     "@taquito/taquito": "^17.0.0",
-    "@ton/ton": "13.11.2",
+    "@ton/ton": "^15.0.0",
     "@vechain/connex-driver": "2.0.12",
     "algosdk": "^2.0.0",
     "bitcoinjs-lib": "^6.0.0",

--- a/packages/lib-ton/package.json
+++ b/packages/lib-ton/package.json
@@ -2,6 +2,6 @@
   "name": "@dfns/lib-ton",
   "version": "0.4.3",
   "peerDependencies": {
-    "@ton/ton": "13.11.2"
+    "@ton/ton": "^15.0.0"
   }
 }


### PR DESCRIPTION
* make signing generic for any wallet contract (especially it works with wallet v5)
* using wallet contract v5 in a simplified example.
* trimmed the example code, got rid of stuff that's not related to demonstrating how Dfns integration works.