### PR TITLE
fix: deprecate recreate registration challenge

### DIFF
--- a/packages/sdk/generated/auth/client.ts
+++ b/packages/sdk/generated/auth/client.ts
@@ -640,26 +640,6 @@ export class AuthClient {
     return this.recover(request)
   }
 
-  async recreateDelegatedRegistrationChallenge(request: T.RecreateDelegatedRegistrationChallengeRequest): Promise<T.RecreateDelegatedRegistrationChallengeResponse> {
-    const path = buildPathAndQuery('/auth/registration/delegated/restart', {
-      path: request ?? {},
-      query: {},
-    })
-
-    const response = await userActionFetch(path, {
-      method: 'POST',
-      body: request.body,
-      apiOptions: this.apiOptions,
-    })
-
-    return response.json()
-  }
-  
-  /** @deprecated, use recreateDelegatedRegistrationChallenge instead */
-  async restartDelegatedUserRegistration(request: T.RecreateDelegatedRegistrationChallengeRequest): Promise<T.RecreateDelegatedRegistrationChallengeResponse> {
-    return this.recreateDelegatedRegistrationChallenge(request)
-  }
-
   async register(request: T.RegisterRequest): Promise<T.RegisterResponse> {
     const path = buildPathAndQuery('/auth/registration', {
       path: request ?? {},

--- a/packages/sdk/generated/auth/delegatedClient.ts
+++ b/packages/sdk/generated/auth/delegatedClient.ts
@@ -1150,49 +1150,6 @@ export class DelegatedAuthClient {
     return this.recover(request)
   }
 
-  async recreateDelegatedRegistrationChallengeInit(request: T.RecreateDelegatedRegistrationChallengeRequest): Promise<UserActionChallengeResponse> {
-    const path = buildPathAndQuery('/auth/registration/delegated/restart', {
-      path: request ?? {},
-      query: {},
-    })
-
-    const challenge = await BaseAuthApi.createUserActionChallenge(
-      {
-        userActionHttpMethod: 'POST',
-        userActionHttpPath: path,
-        userActionPayload: JSON.stringify(request.body),
-        userActionServerKind: 'Api',
-      },
-      this.apiOptions
-    )
-
-    return challenge
-  }
-
-  async recreateDelegatedRegistrationChallengeComplete(
-    request: T.RecreateDelegatedRegistrationChallengeRequest,
-    signedChallenge: SignUserActionChallengeRequest
-  ): Promise<T.RecreateDelegatedRegistrationChallengeResponse> {
-    const path = buildPathAndQuery('/auth/registration/delegated/restart', {
-      path: request ?? {},
-      query: {},
-    })
-
-    const { userAction } = await BaseAuthApi.signUserActionChallenge(
-      signedChallenge,
-      this.apiOptions
-    )
-
-    const response = await simpleFetch(path, {
-      method: 'POST',
-      body: request.body,
-      headers: { 'x-dfns-useraction': userAction },
-      apiOptions: this.apiOptions,
-    })
-
-    return response.json()
-  }
-
   async register(request: T.RegisterRequest): Promise<T.RegisterResponse> {
     const path = buildPathAndQuery('/auth/registration', {
       path: request ?? {},

--- a/packages/sdk/generated/auth/types.ts
+++ b/packages/sdk/generated/auth/types.ts
@@ -652,7 +652,7 @@ export type CreateDelegatedRecoveryChallengeRequest = { body: CreateDelegatedRec
 
 export type CreateDelegatedRegistrationChallengeBody = {
     email: string;
-    kind: "CustomerEmployee" | "DfnsStaff" | "EndUser";
+    kind: "EndUser";
     externalId?: string | undefined;
 };
 
@@ -1665,48 +1665,6 @@ export type RecoverResponse = {
 };
 
 export type RecoverRequest = { body: RecoverBody }
-
-export type RecreateDelegatedRegistrationChallengeBody = {
-    email: string;
-    kind: "CustomerEmployee" | "DfnsStaff" | "EndUser";
-    externalId?: string | undefined;
-};
-
-export type RecreateDelegatedRegistrationChallengeResponse = {
-    user: {
-        id: string;
-        displayName: string;
-        name: string;
-    };
-    temporaryAuthenticationToken: string;
-    challenge: string;
-    rp?: {
-        id: string;
-        name: string;
-    } | undefined;
-    supportedCredentialKinds: {
-        firstFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey" | "PasswordProtectedKey")[];
-        secondFactor: ("Fido2" | "Key" | "Password" | "Totp" | "RecoveryKey" | "PasswordProtectedKey")[];
-    };
-    authenticatorSelection: {
-        authenticatorAttachment?: ("platform" | "cross-platform") | undefined;
-        residentKey: "required" | "preferred" | "discouraged";
-        requireResidentKey: boolean;
-        userVerification: "required" | "preferred" | "discouraged";
-    };
-    attestation: "none" | "indirect" | "direct" | "enterprise";
-    pubKeyCredParams: {
-        type: "public-key";
-        alg: number;
-    }[];
-    excludeCredentials: {
-        type: "public-key";
-        id: string;
-    }[];
-    otpUrl: string;
-};
-
-export type RecreateDelegatedRegistrationChallengeRequest = { body: RecreateDelegatedRegistrationChallengeBody }
 
 export type RegisterBody = {
     firstFactorCredential: {

--- a/packages/sdk/generated/policies/types.ts
+++ b/packages/sdk/generated/policies/types.ts
@@ -5436,26 +5436,6 @@ export type ListPoliciesResponse = {
 
 export type ListPoliciesRequest = { query?: ListPoliciesQuery }
 
-export type NotabeneNotificationsWebhookBody = {
-    message: "notification.transactionUpdated";
-    payload: {
-        transaction: {
-            id: string;
-            status: "NEW" | "WAITING_FOR_INFORMATION" | "MISSING_BENEFICIARY_DATA" | "CANCELLED" | "INCOMPLETE" | "SENT" | "ACK" | "ACCEPTED" | "DECLINED" | "REJECTED" | "NOT_READY" | "SAVED";
-            transactionRef?: (string | null) | undefined;
-            transactionType: "TRAVELRULE" | "BELOW_THRESHOLD" | "NON_CUSTODIAL" | "UNKNOWN";
-        };
-    };
-};
-
-export type NotabeneNotificationsWebhookParams = {
-    orgId: string;
-};
-
-export type NotabeneNotificationsWebhookResponse = void | undefined;
-
-export type NotabeneNotificationsWebhookRequest = NotabeneNotificationsWebhookParams & { body: NotabeneNotificationsWebhookBody }
-
 export type UpdatePolicyBody = {
     name: string;
     activityKind: "Permissions:Assign";


### PR DESCRIPTION
This PR removes the `auth.recreateDelegatedRegistrationChallenge()` method from the SDK, as the `auth.createDelegatedRegistrationChallenge()` method can now be used several times for the same end user, in order to get a new registration challenge.

The `POST /auth/registration/delegated/restart` endpoint is still exposed, but will be discontinued at some point, so users should migrate away from it in favour of `POST /auth/registration/delegated`.