### PR TITLE
Update broken link for `generate a key pair` with the correct one

### DIFF
--- a/examples/libs/algorand/asset-tx/README.md
+++ b/examples/libs/algorand/asset-tx/README.md
@@ -8,7 +8,7 @@ See algosdk's [API Specification](https://algorand.github.io/js-algorand-sdk/) f
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/algorand/basic-tx/README.md
+++ b/examples/libs/algorand/basic-tx/README.md
@@ -6,7 +6,7 @@ See algosdk's [API Specification](https://algorand.github.io/js-algorand-sdk/) f
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/algorand/multisig-tx/README.md
+++ b/examples/libs/algorand/multisig-tx/README.md
@@ -6,7 +6,7 @@ See algosdk's [API Specification](https://algorand.github.io/js-algorand-sdk/) f
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/aptos/basic-tx/README.md
+++ b/examples/libs/aptos/basic-tx/README.md
@@ -6,7 +6,7 @@ See aptos sdk's [documentation](https://aptos.dev/en/build/sdks/ts-sdk) for a co
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/aptos/feepayer-tx/README.md
+++ b/examples/libs/aptos/feepayer-tx/README.md
@@ -6,7 +6,7 @@ See aptos sdk's [documentation](https://aptos.dev/en/build/sdks/ts-sdk) for a co
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/aptos/multiagent-tx/README.md
+++ b/examples/libs/aptos/multiagent-tx/README.md
@@ -7,7 +7,7 @@ See aptos sdk's [example](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/e
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/bitcoinjs/basic-tx/README.md
+++ b/examples/libs/bitcoinjs/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Bitcoin transfer from a Dfns wallet to another addres
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/bitcoinjs/pay-to-multisig/README.md
+++ b/examples/libs/bitcoinjs/pay-to-multisig/README.md
@@ -4,7 +4,7 @@ Adapted from [a tutorial example](https://bitcoinjs-guide.bitcoin-studio.com/bit
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/bitcoinjs/taproot/README.md
+++ b/examples/libs/bitcoinjs/taproot/README.md
@@ -5,7 +5,7 @@ The original blog post about this script can be found there: https://dev.to/euno
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/canton/basic-tx/README.md
+++ b/examples/libs/canton/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a Canton Coin CIP-56 transfer using [Canton SDK](https://docs.digit
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/cosmjs/basic-tx/README.md
+++ b/examples/libs/cosmjs/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Osmosis transfer from a Dfns wallet using [CosmJS](ht
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/ethersjs/v5/arbitrum-deposit-eth/README.md
+++ b/examples/libs/ethersjs/v5/arbitrum-deposit-eth/README.md
@@ -4,7 +4,7 @@ Adapted from Arbitrum's [deposit example](https://github.com/OffchainLabs/arbitr
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/ethersjs/v5/optimism-deposit-eth/README.md
+++ b/examples/libs/ethersjs/v5/optimism-deposit-eth/README.md
@@ -4,7 +4,7 @@ Adapted from Optimism's [bridge eth example](https://github.com/ethereum-optimis
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/ethersjs/v5/polygon-deposit-erc20/README.md
+++ b/examples/libs/ethersjs/v5/polygon-deposit-erc20/README.md
@@ -4,7 +4,7 @@ Adapted from Polygon's [deposit example](https://github.com/maticnetwork/matic.j
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/ethersjs/v6/base-deposit-eth/README.md
+++ b/examples/libs/ethersjs/v6/base-deposit-eth/README.md
@@ -4,7 +4,7 @@ Adapted from Base [deposit example](https://github.com/base-org/guides/blob/main
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/ethersjs/v6/hardhat/README.md
+++ b/examples/libs/ethersjs/v6/hardhat/README.md
@@ -4,7 +4,7 @@ Example showing how to use a Dfns wallet with [Hardhat](https://hardhat.org/) to
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/ethersjs/v6/uniswap/README.md
+++ b/examples/libs/ethersjs/v6/uniswap/README.md
@@ -4,7 +4,7 @@ Adapted from Uniswap's [trading example](https://github.com/Uniswap/examples/blo
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/hedera/basic-tx/README.md
+++ b/examples/libs/hedera/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Hedera transfer from a Dfns wallet to another account
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/iota/basic-tx/README.md
+++ b/examples/libs/iota/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Iota transfer from a Dfns wallet using [Iota-sdk](htt
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/iota/contract-call/README.md
+++ b/examples/libs/iota/contract-call/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Iota contract call from a Dfns wallet using [Iota-sdk
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/iota/lock-unlock-transactions/README.md
+++ b/examples/libs/iota/lock-unlock-transactions/README.md
@@ -4,7 +4,7 @@ Demonstrates how to lock native tokens and then unlock them from a Dfns wallet u
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/kaspa/basic-tx/README.md
+++ b/examples/libs/kaspa/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Kaspa transfer from a Dfns wallet to another address.
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/meshsdk/basic-tx/README.md
+++ b/examples/libs/meshsdk/basic-tx/README.md
@@ -6,7 +6,7 @@ See Blockfrost's [API Specification](https://blockfrost.dev/) and [Mesh document
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/near/basic-tx/README.md
+++ b/examples/libs/near/basic-tx/README.md
@@ -6,7 +6,7 @@ See NEAR's [API Specification](https://docs.near.org/tools/near-api) for a compl
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/polkadot/basic-tx/README.md
+++ b/examples/libs/polkadot/basic-tx/README.md
@@ -6,7 +6,7 @@ See polkadot's [API Specification](https://polkadot.js.org/docs/api/start/typesc
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/polymesh/basic-tx/README.md
+++ b/examples/libs/polymesh/basic-tx/README.md
@@ -7,7 +7,7 @@ See polymesh's [documentation](https://developers.polymesh.network/docs/) for a 
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/polymesh/native-assets/README.md
+++ b/examples/libs/polymesh/native-assets/README.md
@@ -7,7 +7,7 @@ See polymesh's [documentation](https://developers.polymesh.network/docs/originat
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/polymesh/wallet-connect/README.md
+++ b/examples/libs/polymesh/wallet-connect/README.md
@@ -8,7 +8,7 @@ See [WalletConnect](https://docs.reown.com/overview) documentation for additiona
 
 On wallet connect side, you'll need to create a project beforehand. See https://cloud.walletconnect.com/sign-in
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/solana/basic-tx/README.md
+++ b/examples/libs/solana/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Solana transfer from a Dfns wallet to another on-chai
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/solana/durable-nonce-tx/README.md
+++ b/examples/libs/solana/durable-nonce-tx/README.md
@@ -5,7 +5,7 @@ This specific transfer will use [DurableNonce](https://solana.com/fr/developers/
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/solana/mint-creation/README.md
+++ b/examples/libs/solana/mint-creation/README.md
@@ -4,7 +4,7 @@ Adapted from Solana [mint example](https://solana.com/developers/guides/token-ex
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/solana/staking/README.md
+++ b/examples/libs/solana/staking/README.md
@@ -4,7 +4,7 @@ Adapted from Solana Cookbook's [staking example](https://solanacookbook.com/refe
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/stellar/basic-tx/README.md
+++ b/examples/libs/stellar/basic-tx/README.md
@@ -6,7 +6,7 @@ See stellar-sdk's [documentation](https://github.com/stellar/js-stellar-sdk) and
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/sui/basic-tx/README.md
+++ b/examples/libs/sui/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Sui transfer from a Dfns wallet using [Sui SDK](https
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/taquito/basic-tx/README.md
+++ b/examples/libs/taquito/basic-tx/README.md
@@ -6,7 +6,7 @@ See Taquito's [Utils/API Specification](https://tezostaquito.io/) for a complete
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/ton/basic-tx/README.md
+++ b/examples/libs/ton/basic-tx/README.md
@@ -6,7 +6,7 @@ See ton sdk's [documentation](https://github.com/ton-core/ton) for a complete gu
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/tron/basic-tx/README.md
+++ b/examples/libs/tron/basic-tx/README.md
@@ -4,7 +4,7 @@ Demonstrates a very simple Tron transfer from a Dfns wallet to another on-chain 
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/tron/staking/README.md
+++ b/examples/libs/tron/staking/README.md
@@ -4,7 +4,7 @@ See TronWeb's [API Specification](https://tronweb.network/docu/docs/intro/) for 
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/vechain/basic-tx/README.md
+++ b/examples/libs/vechain/basic-tx/README.md
@@ -4,7 +4,7 @@ See Vechain Connex's [API Specification](https://docs.vechain.org/connex/api-spe
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/viem/alchemy-aa-gasless/README.md
+++ b/examples/libs/viem/alchemy-aa-gasless/README.md
@@ -4,7 +4,7 @@ Adapted from Alchemy's [sponsor gas example](https://accountkit.alchemy.com/usin
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/viem/biconomy-aa-gasless/README.md
+++ b/examples/libs/viem/biconomy-aa-gasless/README.md
@@ -4,7 +4,7 @@ Adapted from Biconomy's [send a gasless transaction](https://docs.biconomy.io/tu
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/viem/multicall/README.md
+++ b/examples/libs/viem/multicall/README.md
@@ -5,7 +5,7 @@ In this example we batch send Ethereum to 2 different addresses
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/viem/pimlico-aa-gasless/README.md
+++ b/examples/libs/viem/pimlico-aa-gasless/README.md
@@ -4,7 +4,7 @@ Adapted from Pimlico's [how to create and use a SimpleAccount](https://docs.piml
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/viem/zerodev-aa-gasless/README.md
+++ b/examples/libs/viem/zerodev-aa-gasless/README.md
@@ -4,7 +4,7 @@ Adapted from ZeroDev's [documentation](https://docs.zerodev.app/sdk/core-api/cre
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/libs/xrpl/basic-tx/README.md
+++ b/examples/libs/xrpl/basic-tx/README.md
@@ -6,7 +6,7 @@ See XRPL's [API Specification](https://xrpl.org/references.html) for a complete 
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/sdk/auth-delegated-key-credential/README.md
+++ b/examples/sdk/auth-delegated-key-credential/README.md
@@ -13,7 +13,7 @@ A single backend acts as the orchestrator between the browser and the Dfns API.
 
 ### Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, paste in the generated public key

--- a/examples/sdk/auth-delegated/README.md
+++ b/examples/sdk/auth-delegated/README.md
@@ -12,7 +12,7 @@ A single backend acts as the orchestrator between the browser, Android and iOS a
 
 ### Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, paste in the generated public key

--- a/examples/sdk/export-wallet/README.md
+++ b/examples/sdk/export-wallet/README.md
@@ -26,7 +26,7 @@ Wallet export is an opt-in feature at Dfns. So first, you need to request to Dfn
 
 ### Fill a new `.env`
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/sdk/import-wallet/README.md
+++ b/examples/sdk/import-wallet/README.md
@@ -27,7 +27,7 @@ Wallet import is an opt-in feature at Dfns. So first, you need to request to Dfn
 
 ### Fill a new `.env`
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'

--- a/examples/sdk/nextjs-delegated-recovery/README.md
+++ b/examples/sdk/nextjs-delegated-recovery/README.md
@@ -15,7 +15,7 @@ The end user will sign the action from the web-app, using his WebauthN credentia
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 * Name, choose any name
 * Public Key, the public key from the step 'generate a keypair'

--- a/examples/sdk/nextjs-delegated/README.md
+++ b/examples/sdk/nextjs-delegated/README.md
@@ -15,7 +15,7 @@ The end user will sign the action from the web-app, using his WebauthN credentia
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 * Name, choose any name
 * Public Key, the public key from the step 'generate a keypair'

--- a/examples/sdk/service-account/README.md
+++ b/examples/sdk/service-account/README.md
@@ -4,7 +4,7 @@ Interact with Dfns API using the Typescript SDK through a service account. This 
 
 ## Prerequisites
 
-You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/dfns-docs/advanced-topics/authentication/credentials/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
+You need a `Service Account`. To create a new `Service Account`, first [generate a keypair](https://docs.dfns.co/developers/guides/generate-a-key-pair), then go to `Dfns Dashboard` > `Settings` > `Org Settings` > `Service Accounts` > `New Service Account`, and enter the following information,
 
 - Name, choose any name
 - Public Key, the public key from the step 'generate a keypair'


### PR DESCRIPTION
Change to: https://docs.dfns.co/developers/guides/generate-a-key-pair instead of broken link