### PR TITLE
fix missing await

### DIFF
--- a/packages/lib-viem/index.ts
+++ b/packages/lib-viem/index.ts
@@ -162,13 +162,13 @@ export class DfnsWallet {
     if (this.metadata.boundToEvmNetwork) {
       const res = await this.dfnsClient.wallets.generateSignature({
         walletId: this.metadata.id,
-        body: { kind: 'Transaction', transaction: serializer(transaction) },
+        body: { kind: 'Transaction', transaction: await serializer(transaction) },
       })
 
       assertSigned(res)
       return serializer(transaction, extractSignature(res))
     } else {
-      const hash = keccak256(serializer(transaction))
+      const hash = keccak256(await serializer(transaction))
       const signature = await this.signHash(hash)
       return serializer(transaction, signature)
     }


### PR DESCRIPTION
```sh
$ node -v
v24.11.1
$ npm -v
11.6.3
```

`npm run cb:all` fails with:

```sh
    ✔  nx run lib-hedera:cb (2s)

    ✖  nx run lib-viem:cb
       Option "updateBuildableProjectDepsInPackageJson" is deprecated: Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17.
       Compiling TypeScript files for project "lib-viem"...
       packages/lib-viem/index.ts:165:38 - error TS2322: Type 'MaybePromise<`0x${string}`>' is not assignable to type 'string'.
         Type 'Promise<`0x${string}`>' is not assignable to type 'string'.

       165         body: { kind: 'Transaction', transaction: serializer(transaction) },
                                                ~~~~~~~~~~~
       packages/lib-viem/index.ts:171:30 - error TS2345: Argument of type 'MaybePromise<`0x${string}`>' is not assignable to parameter of type '`0x${string}` | ByteArray'.
         Type 'Promise<`0x${string}`>' is not assignable to type '`0x${string}` | ByteArray'.
           Type 'Promise<`0x${string}`>' is missing the following properties from type 'Uint8Array<ArrayBufferLike>': BYTES_PER_ELEMENT, buffer, byteLength, byteOffset, and 26 more.

       171       const hash = keccak256(serializer(transaction))
                                        ~~~~~~~~~~~~~~~~~~~~~~~



    ✔  nx run lib-xrpl:cb (1s)
    ✔  nx run lib-sui:cb (1s)
    ✔  nx run lib-ton:cb (1s)

 ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Ran target cb for 31 projects (14s)

    ✔    30/31 succeeded [0 read from cache]

    ✖    1/31 targets failed, including the following:
         - nx run lib-viem:cb
```

Fixed by awaiting the promises