### PR TITLE
fix: add repository url for provenance attestation

### DIFF
--- a/packages/lib-algorand/package.json
+++ b/packages/lib-algorand/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-algorand",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-algorand"
+  },
   "peerDependencies": {
     "algosdk": "^2.0.0"
   }

--- a/packages/lib-aptos/package.json
+++ b/packages/lib-aptos/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-aptos",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-aptos"
+  },
   "peerDependencies": {
     "@aptos-labs/ts-sdk": "5.0.0"
   }

--- a/packages/lib-bitcoinjs/package.json
+++ b/packages/lib-bitcoinjs/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-bitcoinjs",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-bitcoinjs"
+  },
   "peerDependencies": {
     "bitcoinjs-lib": "^6.0.0"
   }

--- a/packages/lib-concordium/package.json
+++ b/packages/lib-concordium/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-concordium",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-concordium"
+  },
   "peerDependencies": {
     "@concordium/web-sdk": "12.0.0-alpha.3"
   }

--- a/packages/lib-cosmjs/package.json
+++ b/packages/lib-cosmjs/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-cosmjs",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-cosmjs"
+  },
   "peerDependencies": {
     "@cosmjs/crypto": "^0.32.0",
     "@cosmjs/encoding": "^0.32.0",

--- a/packages/lib-ethersjs5/package.json
+++ b/packages/lib-ethersjs5/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/lib-ethersjs5",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-ethersjs5"
+  }
 }

--- a/packages/lib-ethersjs6/package.json
+++ b/packages/lib-ethersjs6/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-ethersjs6",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-ethersjs6"
+  },
   "peerDependencies": {
     "ethers": "^6.0.0"
   }

--- a/packages/lib-hedera/package.json
+++ b/packages/lib-hedera/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-hedera",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-hedera"
+  },
   "peerDependencies": {
     "@hashgraph/sdk": "^2.70.0"
   }

--- a/packages/lib-iota/package.json
+++ b/packages/lib-iota/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-iota",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-iota"
+  },
   "peerDependencies": {
     "@iota/iota-sdk": "^0.4.0"
   }

--- a/packages/lib-kaspa/package.json
+++ b/packages/lib-kaspa/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-kaspa",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-kaspa"
+  },
   "peerDependencies": {
     "@dfns/kaspa-wasm": "0.14.1"
   }

--- a/packages/lib-meshsdk/package.json
+++ b/packages/lib-meshsdk/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-meshsdk",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-meshsdk"
+  },
   "peerDependencies": {
     "@meshsdk/common": "^1.9.0-beta.74"
   }

--- a/packages/lib-near/package.json
+++ b/packages/lib-near/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-near",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-near"
+  },
   "peerDependencies": {
     "near-api-js": "^6.0.0"
   }

--- a/packages/lib-polkadot/package.json
+++ b/packages/lib-polkadot/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-polkadot",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-polkadot"
+  },
   "peerDependencies": {
     "@polkadot/api": "^11.0.0"
   }

--- a/packages/lib-polymesh/package.json
+++ b/packages/lib-polymesh/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-polymesh",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-polymesh"
+  },
   "peerDependencies": {
     "@polkadot/api": "^11.0.0",
     "@polymeshassociation/signing-manager-types": "3.4.0"

--- a/packages/lib-solana/package.json
+++ b/packages/lib-solana/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-solana",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-solana"
+  },
   "peerDependencies": {
     "@solana/web3.js": "^1.0.0"
   }

--- a/packages/lib-stellar/package.json
+++ b/packages/lib-stellar/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-stellar",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-stellar"
+  },
   "peerDependencies": {
     "@stellar/stellar-sdk": "^11.0.0"
   }

--- a/packages/lib-sui/package.json
+++ b/packages/lib-sui/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-sui",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-sui"
+  },
   "peerDependencies": {
     "@mysten/sui": "^1.0.0"
   }

--- a/packages/lib-taquito/package.json
+++ b/packages/lib-taquito/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-taquito",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-taquito"
+  },
   "peerDependencies": {
     "@taquito/taquito": "^17.0.0"
   }

--- a/packages/lib-ton/package.json
+++ b/packages/lib-ton/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-ton",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-ton"
+  },
   "peerDependencies": {
     "@ton/ton": "^15.0.0"
   }

--- a/packages/lib-tron/package.json
+++ b/packages/lib-tron/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-tron",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-tron"
+  },
   "peerDependencies": {
     "tronweb": "6.1.1"
   }

--- a/packages/lib-vechain/package.json
+++ b/packages/lib-vechain/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-vechain",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-vechain"
+  },
   "peerDependencies": {
     "@vechain/sdk-core": "^2.0.5",
     "@vechain/sdk-network": "^2.0.5"

--- a/packages/lib-viem/package.json
+++ b/packages/lib-viem/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-viem",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-viem"
+  },
   "peerDependencies": {
     "@noble/curves": "^1.0.0",
     "viem": "^2.0.0"

--- a/packages/lib-xrpl/package.json
+++ b/packages/lib-xrpl/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/lib-xrpl",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/lib-xrpl"
+  },
   "peerDependencies": {
     "xrpl": "4.4.3"
   }

--- a/packages/sdk-awskmssigner/package.json
+++ b/packages/sdk-awskmssigner/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/sdk-awskmssigner",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk-awskmssigner"
+  }
 }

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@dfns/sdk-browser",
   "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk-browser"
+  },
   "dependencies": {
     "buffer": "6.0.3"
   }

--- a/packages/sdk-keyexport-utils-bundler/package.json
+++ b/packages/sdk-keyexport-utils-bundler/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/sdk-keyexport-utils-bundler",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk-keyexport-utils-bundler"
+  }
 }

--- a/packages/sdk-keyexport-utils-nodejs/package.json
+++ b/packages/sdk-keyexport-utils-nodejs/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/sdk-keyexport-utils-nodejs",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk-keyexport-utils-nodejs"
+  }
 }

--- a/packages/sdk-keyimport-utils-bundler/package.json
+++ b/packages/sdk-keyimport-utils-bundler/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/sdk-keyimport-utils-bundler",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk-keyimport-utils-bundler"
+  }
 }

--- a/packages/sdk-keyimport-utils-nodejs/package.json
+++ b/packages/sdk-keyimport-utils-nodejs/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/sdk-keyimport-utils-nodejs",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk-keyimport-utils-nodejs"
+  }
 }

--- a/packages/sdk-keysigner/package.json
+++ b/packages/sdk-keysigner/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/sdk-keysigner",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk-keysigner"
+  }
 }

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/sdk-react-native",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk-react-native"
+  }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@dfns/sdk",
-  "version": "0.8.16"
+  "version": "0.8.16",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "directory": "packages/sdk"
+  }
 }


### PR DESCRIPTION
NPM requires `repository.url` to be set in order to deliver provenance attestation.