### PR TITLE
ci: use single workflow to publish

### DIFF
--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -17,7 +17,6 @@ jobs:
       deployment: false
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Validate version
         env:
@@ -84,5 +83,12 @@ jobs:
             echo "tag=$PRERELEASE_ID" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish to npm
-        run: ./scripts/publish.sh ${{ steps.npm-tag.outputs.tag }}
+      - name: Trigger publish workflow
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ -n "${{ steps.npm-tag.outputs.tag }}" ]; then
+            gh workflow run publish.yaml -f tag=${{ steps.npm-tag.outputs.tag }}
+          else
+            gh workflow run publish.yaml
+          fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,16 @@
-# only to be used if release was sucessful but publishing failed (e.g network error)
-name: recovery-only-publish
+name: publish
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "npm dist-tag for prerelease (e.g. beta, rc). Leave empty for latest."
+        type: string
+        required: false
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -17,20 +25,18 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
+          ref: m
 
-      - name: install node
+      - name: Install node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
-      - name: install packages
+      - name: Install packages
         run: |
           npm config set ignore-scripts true
           npm ci --prefer-offline --no-audit --cache .npm
 
-      - name: publish packages
-        run: |
-          ./scripts/publish.sh
-
-
+      - name: Publish packages
+        run: ./scripts/publish.sh ${{ inputs.tag }}

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -12,7 +12,6 @@ jobs:
       deployment: false
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -34,3 +33,9 @@ jobs:
             @semantic-release/exec
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Trigger publish workflow
+        if: steps.semantic_release.outputs.new_release_published == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh workflow run publish.yaml

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,10 +4,11 @@ tagFormat: ${version}
 plugins:
   - - "@semantic-release/commit-analyzer"
     - releaseRules: []
-  - "@semantic-release/github"
+  - - "@semantic-release/github"
+    - successComment: false
+      failComment: false
   - - "@semantic-release/exec"
     - prepareCmd: "./scripts/prepare.sh ${nextRelease.version}"
-      publishCmd: "./scripts/publish.sh"
       verifyReleaseCmd: "echo \"NEXT_RELEASE_VERSION=${nextRelease.version}\" >> $GITHUB_ENV"
   - - "@semantic-release/git"
     - assets:

--- a/packages/lib-algorand/package.json
+++ b/packages/lib-algorand/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-algorand"
   },
   "peerDependencies": {

--- a/packages/lib-aptos/package.json
+++ b/packages/lib-aptos/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-aptos"
   },
   "peerDependencies": {

--- a/packages/lib-bitcoinjs/package.json
+++ b/packages/lib-bitcoinjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-bitcoinjs"
   },
   "peerDependencies": {

--- a/packages/lib-concordium/package.json
+++ b/packages/lib-concordium/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-concordium"
   },
   "peerDependencies": {

--- a/packages/lib-cosmjs/package.json
+++ b/packages/lib-cosmjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-cosmjs"
   },
   "peerDependencies": {

--- a/packages/lib-ethersjs5/package.json
+++ b/packages/lib-ethersjs5/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-ethersjs5"
   }
 }

--- a/packages/lib-ethersjs6/package.json
+++ b/packages/lib-ethersjs6/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-ethersjs6"
   },
   "peerDependencies": {

--- a/packages/lib-hedera/package.json
+++ b/packages/lib-hedera/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-hedera"
   },
   "peerDependencies": {

--- a/packages/lib-iota/package.json
+++ b/packages/lib-iota/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-iota"
   },
   "peerDependencies": {

--- a/packages/lib-kaspa/package.json
+++ b/packages/lib-kaspa/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-kaspa"
   },
   "peerDependencies": {

--- a/packages/lib-meshsdk/package.json
+++ b/packages/lib-meshsdk/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-meshsdk"
   },
   "peerDependencies": {

--- a/packages/lib-near/package.json
+++ b/packages/lib-near/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-near"
   },
   "peerDependencies": {

--- a/packages/lib-polkadot/package.json
+++ b/packages/lib-polkadot/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-polkadot"
   },
   "peerDependencies": {

--- a/packages/lib-polymesh/package.json
+++ b/packages/lib-polymesh/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-polymesh"
   },
   "peerDependencies": {

--- a/packages/lib-solana/package.json
+++ b/packages/lib-solana/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-solana"
   },
   "peerDependencies": {

--- a/packages/lib-stellar/package.json
+++ b/packages/lib-stellar/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-stellar"
   },
   "peerDependencies": {

--- a/packages/lib-sui/package.json
+++ b/packages/lib-sui/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-sui"
   },
   "peerDependencies": {

--- a/packages/lib-taquito/package.json
+++ b/packages/lib-taquito/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-taquito"
   },
   "peerDependencies": {

--- a/packages/lib-ton/package.json
+++ b/packages/lib-ton/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-ton"
   },
   "peerDependencies": {

--- a/packages/lib-tron/package.json
+++ b/packages/lib-tron/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-tron"
   },
   "peerDependencies": {

--- a/packages/lib-vechain/package.json
+++ b/packages/lib-vechain/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-vechain"
   },
   "peerDependencies": {

--- a/packages/lib-viem/package.json
+++ b/packages/lib-viem/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-viem"
   },
   "peerDependencies": {

--- a/packages/lib-xrpl/package.json
+++ b/packages/lib-xrpl/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/lib-xrpl"
   },
   "peerDependencies": {

--- a/packages/sdk-awskmssigner/package.json
+++ b/packages/sdk-awskmssigner/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk-awskmssigner"
   }
 }

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk-browser"
   },
   "dependencies": {

--- a/packages/sdk-keyexport-utils-bundler/package.json
+++ b/packages/sdk-keyexport-utils-bundler/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk-keyexport-utils-bundler"
   }
 }

--- a/packages/sdk-keyexport-utils-nodejs/package.json
+++ b/packages/sdk-keyexport-utils-nodejs/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk-keyexport-utils-nodejs"
   }
 }

--- a/packages/sdk-keyimport-utils-bundler/package.json
+++ b/packages/sdk-keyimport-utils-bundler/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk-keyimport-utils-bundler"
   }
 }

--- a/packages/sdk-keyimport-utils-nodejs/package.json
+++ b/packages/sdk-keyimport-utils-nodejs/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk-keyimport-utils-nodejs"
   }
 }

--- a/packages/sdk-keysigner/package.json
+++ b/packages/sdk-keysigner/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk-keysigner"
   }
 }

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk-react-native"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.17",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfns/dfns-sdk-ts",
+    "url": "git+https://github.com/dfns/dfns-sdk-ts.git",
     "directory": "packages/sdk"
   }
 }


### PR DESCRIPTION
- Only use `publish.yaml` to publish because npm will only allow saving a single trusted workflow
- Remove npm warnings