### PR TITLE
Preserve false query parameters

### DIFF
--- a/packages/sdk/utils/url.ts
+++ b/packages/sdk/utils/url.ts
@@ -14,7 +14,7 @@ export const buildPathAndQuery = (
     .flatMap(([key, value]) => {
       if (Array.isArray(value)) {
         return value.map((item) => `${key}=${encodeURIComponent(item)}`)
-      } else if (!value) {
+      } else if (value === undefined) {
         return []
       } else {
         return [`${key}=${encodeURIComponent(value.toString())}`]


### PR DESCRIPTION
Updates query serialization so only `undefined` values are omitted. Boolean `false` values are now preserved as `key=false`, which matters for endpoints with boolean query flags such as `force`.