### PR TITLE
fix(examples): fix Zama ACL mainnet address in delegate-fhe-decrypt example

### DIFF
--- a/examples/libs/ethersjs/v6/delegate-fhe-decrypt/README.md
+++ b/examples/libs/ethersjs/v6/delegate-fhe-decrypt/README.md
@@ -22,12 +22,12 @@ Copy `.env.example` to a new file `.env` and set the following values,
 - `DFNS_CRED_ID` = the `Signing Key Cred ID` from above
 - `DFNS_PRIVATE_KEY` = the private key from the step 'generate a keypair', the newlines should not be a problem
 - `DFNS_AUTH_TOKEN` = the `authToken` from above, the value should start with `eyJ0...`
-- `WALLET_ID` = a Dfns Ethereum Sepolia [wallet](https://docs.dfns.co/dfns-docs/api-docs/beta-wallets-api-and-nfts/create-wallet)
-- `ERC7984_CONTRACT` = the ERC-7984 confidential token contract address
-- `DELEGATEE_ADDRESS` = the Dfns delegatee address (see below)
-- `ETHEREUM_SEPOLIA_NODE_URL` = an Ethereum Sepolia RPC provider node you have access to
+- `ETHEREUM_WALLET_ID` = a Dfns Ethereum [wallet](https://docs.dfns.co/dfns-docs/api-docs/beta-wallets-api-and-nfts/create-wallet) on the network you want to use (Ethereum Mainnet or Sepolia)
+- `ERC7984_CONTRACT_ADDRESS` = the ERC-7984 confidential token contract address
+- `ERC7984_DELEGATEE_ADDRESS` = the Dfns delegatee address (see below)
+- `ETHEREUM_NODE_URL` = an Ethereum RPC provider node you have access to, on the same network as your wallet (Mainnet or Sepolia)
 
-**note** _the wallet must have Sepolia ETH to pay for gas_
+**note** _the wallet must hold native ETH on the chosen network (Mainnet or Sepolia) to pay for gas_
 
 ## Dfns Delegatee Address
 
@@ -38,14 +38,25 @@ For Dfns to be able to decrypt your confidential balances and display them in pl
 | Sepolia Testnet  | `0x1f4252accc541a7a37868e02031b85ea00245d73` |
 | Ethereum Mainnet | `0x1f4252accc541a7a37868e02031b85ea00245d73` |
 
-Set `DELEGATEE_ADDRESS` in your `.env` to the address matching your network. Without this delegation, Dfns will return the encrypted handle instead of the plaintext balance.
+Set `ERC7984_DELEGATEE_ADDRESS` in your `.env` to the address matching your network. Without this delegation, Dfns will return the encrypted handle instead of the plaintext balance.
+
+## Supported networks
+
+FHE is supported on Ethereum Mainnet and Ethereum Sepolia. The Zama ACL contract address differs between the two, so the example selects it automatically from the chain ID of `ETHEREUM_NODE_URL`:
+
+| Network          | chainId  | Zama ACL contract                            |
+| ---------------- | -------- | -------------------------------------------- |
+| Ethereum Mainnet | 1        | `0xcA2E8f1F656CD25C01F05d0b243Ab1ecd4a8ffb6` |
+| Ethereum Sepolia | 11155111 | `0xf0Ffdc93b7E186bC2f8CB3dAA75D86d1930A433D` |
+
+These match Zama's published [contract addresses](https://docs.zama.org/protocol/solidity-guides/smart-contract/configure/contract_addresses).
 
 ## Explanation
 
-The program calls `ACL.delegateForUserDecryption(delegate, contractAddress, expirationDate)` on the [Zama ACL contract](https://docs.zama.ai/fhevm/fundamentals/acl). This grants the delegatee address permission
+The program calls `ACL.delegateForUserDecryption(delegate, contractAddress, expirationDate)` on the [Zama ACL contract](https://docs.zama.org/protocol/solidity-guides/smart-contract/acl) for the connected network. This grants the delegatee address permission
 to decrypt the wallet owner's encrypted balances and transfer amounts for the specified ERC-7984 token contract.
 
-The delegation expires after 1 year by default. Once delegated, Dfns can automatically decrypt confidential balances and display them in plaintext through the [Get Wallet
+The delegation is permanent by default (`expirationDate` is set to the maximum `uint64`); set a finite timestamp in `main.ts` if you want it to expire. Once delegated, Dfns can automatically decrypt confidential balances and display them in plaintext through the [Get Wallet
 Assets](https://docs.dfns.co/api-reference/wallets/get-wallet-assets) and [Get Wallet History](https://docs.dfns.co/api-reference/wallets/get-wallet-history) endpoints.
 
 ```shell
@@ -54,8 +65,8 @@ Assets](https://docs.dfns.co/api-reference/wallets/get-wallet-assets) and [Get W
 Wallet:     0x956fbb0c88b3c597d4afdbab3e26939051ff6725
 Delegatee:  0x60C09563Ec6908cdc3FcAE7dd31902beC8124E7F
 Contract:   0x593E77e7E2bEe748aa27942E1f2069b5B6902625
-ACL:        0xf0Ffdc93b7E186bC2f8CB3dAA75D86d1930A433D
-Expiration: 2027-03-27T00:00:00.000Z
+ACL:        0xf0Ffdc93b7E186bC2f8CB3dAA75D86d1930A433D (chainId 11155111)
+Expiration: permanent
 
 Delegating FHE decrypt rights...
 Transaction sent: 0x697b6b8d0465b21ccaeb1edb09b34cb92af74ad393ce4494a543188b8c774090

--- a/examples/libs/ethersjs/v6/delegate-fhe-decrypt/main.ts
+++ b/examples/libs/ethersjs/v6/delegate-fhe-decrypt/main.ts
@@ -6,8 +6,12 @@ import { Contract, JsonRpcProvider } from 'ethers'
 
 dotenv.config()
 
-// Zama ACL contract (same address on Sepolia and Mainnet)
-const ACL_CONTRACT = '0xf0Ffdc93b7E186bC2f8CB3dAA75D86d1930A433D'
+// Zama FHEVM ACL contract, per network — the address differs between chains.
+// Verified against zama-ai/fhevm `library-solidity/config/ZamaConfig.sol`.
+const ACL_CONTRACTS: Record<number, string> = {
+  1: '0xcA2E8f1F656CD25C01F05d0b243Ab1ecd4a8ffb6', // Ethereum Mainnet
+  11155111: '0xf0Ffdc93b7E186bC2f8CB3dAA75D86d1930A433D', // Ethereum Sepolia
+}
 
 const ACL_ABI = [
   'function delegateForUserDecryption(address delegate, address contractAddress, uint64 expirationDate)',
@@ -16,7 +20,7 @@ const ACL_ABI = [
 
 const MAX_UINT64 = 2n ** 64n - 1n
 
-const sepolia = new JsonRpcProvider(process.env.ETHEREUM_NODE_URL!)
+const provider = new JsonRpcProvider(process.env.ETHEREUM_NODE_URL!)
 
 const initDfnsWallet = async (walletId: string) => {
   const signer = new AsymmetricKeySigner({
@@ -35,8 +39,18 @@ const initDfnsWallet = async (walletId: string) => {
 }
 
 const main = async () => {
-  const wallet = (await initDfnsWallet(process.env.ETHEREUM_WALLET_ID!)).connect(sepolia)
+  const wallet = (await initDfnsWallet(process.env.ETHEREUM_WALLET_ID!)).connect(provider)
   const walletAddress = await wallet.getAddress()
+
+  // Pick the ACL contract for the network the provider is actually connected to.
+  const { chainId } = await provider.getNetwork()
+  const aclContract = ACL_CONTRACTS[Number(chainId)]
+  if (!aclContract) {
+    throw new Error(
+      `No Zama FHEVM ACL configured for chainId ${chainId}. ` +
+        `Supported networks: Ethereum Mainnet (1) and Ethereum Sepolia (11155111).`
+    )
+  }
 
   const delegateeAddress = process.env.ERC7984_DELEGATEE_ADDRESS!
   const erc7984Contract = process.env.ERC7984_CONTRACT_ADDRESS!
@@ -47,11 +61,11 @@ const main = async () => {
   console.log(`Wallet:     ${walletAddress}`)
   console.log(`Delegatee:  ${delegateeAddress}`)
   console.log(`Contract:   ${erc7984Contract}`)
-  console.log(`ACL:        ${ACL_CONTRACT}`)
+  console.log(`ACL:        ${aclContract} (chainId ${chainId})`)
   console.log(`Expiration: ${expirationDate === MAX_UINT64 ? 'permanent': new Date((expirationDate * 1000n).toString()).toISOString()}`)
   console.log()
 
-  const acl = new Contract(ACL_CONTRACT, ACL_ABI, wallet)
+  const acl = new Contract(aclContract, ACL_ABI, wallet)
 
   // Check if delegation already exists
   const existing = await acl.getUserDecryptionDelegationExpirationDate(walletAddress, delegateeAddress, erc7984Contract)


### PR DESCRIPTION
Zama example: selects the ACL address per-chain (mainnet address was incorrect)

Addresses verified against zama-ai/fhevm library-solidity/config/ZamaConfig.sol and confirmed live on-chain.

corrects the delegation-expiry note to reflect the permanent default.