### PR TITLE
chore(examples): remove deprecated DFNS_APP_ID/appId

### DIFF
--- a/examples/libs/concordium/wallet-activation-id-app/.env.example
+++ b/examples/libs/concordium/wallet-activation-id-app/.env.example
@@ -1,5 +1,4 @@
 DFNS_API_URL='https://api.dfns.ninja'
-DFNS_APP_ID='ap-gcnp5...<redacted>...'
 DFNS_CRED_ID='Y2kt...<redacted>...'
 DFNS_PRIVATE_KEY='-----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEAxWRXN5iLhFyIucblxPY7zjbSKc3qpjcnF9g2pdN+HcMhH+hK

--- a/examples/libs/iota/contract-call/.env.example
+++ b/examples/libs/iota/contract-call/.env.example
@@ -1,5 +1,4 @@
 DFNS_API_URL='https://api.dfns.ninja'
-DFNS_APP_ID='ap-gcnp5...<redacted>...'
 DFNS_CRED_ID='Y2kt...<redacted>...'
 DFNS_PRIVATE_KEY='-----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEAxWRXN5iLhFyIucblxPY7zjbSKc3qpjcnF9g2pdN+HcMhH+hK

--- a/examples/libs/iota/contract-call/README.md
+++ b/examples/libs/iota/contract-call/README.md
@@ -16,7 +16,6 @@ Go back to the service accounts listing, and the new `Service Account` should be
 Copy `.env.example` to a new file `.env` and set the following values,
 
 - `DFNS_API_URL` = `https://api.dfns.ninja`
-- `DFNS_APP_ID` = Dfns Application ID (grab one in Dfns Dashboard: `Settings` > `Applications`)
 - `DFNS_CRED_ID` = the `Signing Key Cred ID` from above
 - `DFNS_PRIVATE_KEY` = the private key from the step 'generate a keypair', the newlines should not be a problem
 - `DFNS_AUTH_TOKEN` = the `authToken` from above, the value should start with `eyJ0...`

--- a/examples/libs/iota/contract-call/main.ts
+++ b/examples/libs/iota/contract-call/main.ts
@@ -15,7 +15,6 @@ const initDfnsWallet = async (walletId: string) => {
   })
 
   const dfnsClient = new DfnsApiClient({
-    appId: process.env.DFNS_APP_ID!,
     authToken: process.env.DFNS_AUTH_TOKEN!,
     baseUrl: process.env.DFNS_API_URL!,
     signer,

--- a/examples/libs/polymesh/wallet-connect/.env.example
+++ b/examples/libs/polymesh/wallet-connect/.env.example
@@ -1,5 +1,4 @@
 DFNS_API_URL='https://api.dfns.ninja'
-DFNS_APP_ID='ap-gcnp5...<redacted>...'
 DFNS_CRED_ID='Y2kt...<redacted>...'
 DFNS_PRIVATE_KEY='-----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEAxWRXN5iLhFyIucblxPY7zjbSKc3qpjcnF9g2pdN+HcMhH+hK


### PR DESCRIPTION
## What

Removes the deprecated `appId` / `DFNS_APP_ID` from the remaining SDK examples. `appId` is deprecated (see `applications-deprecation.mdx` in the docs repo) and is no longer part of `DfnsApiClientOptions` — the SDK ignores it.

## Why

- Stops new users from copying deprecated config out of the canonical examples.
- Aligns examples with the deprecation notice already published in the docs.
- In `iota/contract-call/main.ts`, `appId` was an **excess property** against the current `DfnsApiClientOptions` type, so passing it was a latent type error.

## Changes (removals only, no replacements needed)

- `examples/libs/concordium/wallet-activation-id-app/.env.example` — drop `DFNS_APP_ID`
- `examples/libs/iota/contract-call/.env.example` — drop `DFNS_APP_ID`
- `examples/libs/iota/contract-call/README.md` — drop the `DFNS_APP_ID` env-var bullet
- `examples/libs/iota/contract-call/main.ts` — drop `appId: process.env.DFNS_APP_ID!` from the `DfnsApiClient` config
- `examples/libs/polymesh/wallet-connect/.env.example` — drop `DFNS_APP_ID`

A repo-wide grep across `examples/` confirms no remaining `appId` / `DFNS_APP_ID` references (outside `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)