### PR TITLE
fix: include license in published packages

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -43,6 +43,7 @@ packages=(
 )
 
 for packageName in "${packages[@]}"; do
+    cp LICENSE dist/"${packageName}"/LICENSE
     cd dist/"${packageName}"
     version=$(node -p "require('./package.json').version")
     if npm view "${packageName}@${version}" version >/dev/null 2>&1; then


### PR DESCRIPTION
Copies the repository LICENSE into every generated package directory before npm publish, covering all release workflows that invoke the shared publish script.

Verification:
- NX_DAEMON=false npm run cb:all
- npm pack --dry-run includes LICENSE for all 33 packages
- bash -n scripts/publish.sh
- git diff --check