### PR TITLE
fix: publish package license metadata

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 tag=${1:-}
+license=$(node -p "require('./package.json').license")
 
 npm run cb:all
 
@@ -45,6 +46,7 @@ packages=(
 for packageName in "${packages[@]}"; do
     cp LICENSE dist/"${packageName}"/LICENSE
     cd dist/"${packageName}"
+    npm pkg set "license=${license}" --workspaces=false
     version=$(node -p "require('./package.json').version")
     if npm view "${packageName}@${version}" version >/dev/null 2>&1; then
         echo "Skipping ${packageName}@${version} (already published)"


### PR DESCRIPTION
Follow-up to #673. The LICENSE file is now bundled in each package, but npmjs.com reads the displayed license from the published package.json metadata.

This copies the root MIT SPDX identifier into every generated package manifest before publishing.

Verification:
- NX_DAEMON=false npm run cb:all
- Confirmed license: MIT in all 33 generated manifests
- Confirmed LICENSE in npm pack --dry-run output for all 33 packages
- bash -n scripts/publish.sh
- git diff --check