### PR TITLE
feat: support path-based API base URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "prepare": "husky",
     "cb:all": "rimraf dist && nx run-many -t=cb",
-    "docs": "typedoc"
+    "docs": "typedoc",
+    "test:sdk": "NX_DAEMON=false nx run sdk:cb && node --test packages/sdk/utils/routing.spec.cjs"
   },
   "dependencies": {
     "@aptos-labs/ts-sdk": "^5.0.0",

--- a/packages/sdk/baseAuthApi.ts
+++ b/packages/sdk/baseAuthApi.ts
@@ -12,13 +12,14 @@ import {
   UserActionChallenge,
 } from './signer'
 import { HttpMethod, simpleFetch } from './utils/fetch'
+import { getCanonicalPath } from './utils/url'
 import { DfnsBaseApiOptions } from './types/generic'
 
 export type CreateUserActionChallengeRequest = {
   userActionPayload: string
   userActionHttpMethod: HttpMethod
   userActionHttpPath: string
-  userActionServerKind: 'Api'
+  userActionServerKind: string
 }
 
 export type UserActionChallengeResponse = UserActionChallenge
@@ -94,7 +95,10 @@ export class BaseAuthApi {
   ): Promise<UserActionChallengeResponse> {
     const response = await simpleFetch('/auth/action/init', {
       method: 'POST',
-      body: request,
+      body: {
+        ...request,
+        userActionHttpPath: getCanonicalPath(request.userActionHttpPath),
+      },
       apiOptions: options,
     })
 

--- a/packages/sdk/types/generic.ts
+++ b/packages/sdk/types/generic.ts
@@ -1,12 +1,16 @@
 import { CredentialSigner } from '../signer'
 
 export type DfnsBaseApiOptions = {
-  /** Only needs to be specified when using another API environment */
+  /** Complete transport base URL. It may include a deployment-specific path prefix. */
   baseUrl?: string
   /** Auth token needs to be specified to use any endpoint that requires authentication */
   authToken?: string
   /** If orgId is specified, and an auth token is used, then before API requests are sent, a check will be performed that the auth token is indeed scoped to the expected org. That can be useful in the context of multi-org */
   orgId?: string
+  /** Base URL used for user-action challenge requests. Defaults to baseUrl. */
+  baseAuthUrl?: string
+  /** User-action server kind. Defaults to Api. */
+  userActionServerKind?: string
 }
 
 export type DfnsApiClientOptions = DfnsBaseApiOptions & {

--- a/packages/sdk/utils/fetch.ts
+++ b/packages/sdk/utils/fetch.ts
@@ -4,6 +4,7 @@ import { DfnsError, PolicyPendingError } from '../dfnsError'
 import { DfnsBaseApiOptions } from '../types/generic'
 import { assertAuthTokenIsSameOrg } from './authToken'
 import { sha256 } from './sha256'
+import { buildApiUrl, getCanonicalPath } from './url'
 
 const DEFAULT_DFNS_BASE_URL = 'https://api.dfns.io'
 
@@ -17,6 +18,8 @@ export type FetchOptions<T> = {
   body?: string | unknown
   file?: { bytes: Uint8Array; name?: string }
   apiOptions: T
+  /** Canonical API route, excluding any deployment-specific base path. */
+  userActionHttpPath?: string
 }
 
 export type Fetch<T> = (resource: string | URL, options: FetchOptions<T>) => Promise<Response>
@@ -24,8 +27,9 @@ export type Fetch<T> = (resource: string | URL, options: FetchOptions<T>) => Pro
 export const fullUrl = <T extends DfnsBaseApiOptions>(fetch: Fetch<T>): Fetch<T> => {
   return async (resource, options) => {
     const baseUrl = options.apiOptions.baseUrl || DEFAULT_DFNS_BASE_URL
-    resource = new URL(resource, baseUrl)
-    return fetch(resource, options)
+    const userActionHttpPath = options.userActionHttpPath ?? getCanonicalPath(resource)
+    resource = buildApiUrl(resource, baseUrl)
+    return fetch(resource, { ...options, userActionHttpPath })
   }
 }
 

--- a/packages/sdk/utils/routing.spec.cjs
+++ b/packages/sdk/utils/routing.spec.cjs
@@ -1,0 +1,86 @@
+/* eslint-env node */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const assert = require('node:assert/strict')
+const { afterEach, describe, it } = require('node:test')
+
+const fetchModule = require('../../../dist/@dfns/sdk/utils/fetch.js')
+const { buildApiUrl, getCanonicalPath } = require('../../../dist/@dfns/sdk/utils/url.js')
+
+const originalSimpleFetch = fetchModule.simpleFetch
+
+afterEach(() => {
+  fetchModule.simpleFetch = originalSimpleFetch
+})
+
+describe('API URL routing', () => {
+  it('preserves legacy root URL behavior', () => {
+    assert.equal(
+      buildApiUrl('/wallets?limit=10', 'https://api.dfns.io').toString(),
+      'https://api.dfns.io/wallets?limit=10'
+    )
+  })
+
+  it('preserves a deployment path prefix', () => {
+    assert.equal(
+      buildApiUrl('/wallets?limit=10', 'https://dfns.example.com/api').toString(),
+      'https://dfns.example.com/api/wallets?limit=10'
+    )
+  })
+
+  it('normalizes a trailing slash on the base URL', () => {
+    assert.equal(
+      buildApiUrl('/staff/orgs', 'https://dfns.example.com/api-staff/').toString(),
+      'https://dfns.example.com/api-staff/staff/orgs'
+    )
+  })
+
+  it('keeps the deployment prefix out of the canonical signing path', () => {
+    assert.equal(getCanonicalPath('/wallets?limit=10'), '/wallets')
+    assert.equal(getCanonicalPath('/staff/orgs?status=Active'), '/staff/orgs')
+  })
+
+  it('threads the canonical path separately from the transport URL', async () => {
+    let captured
+    const fetch = fetchModule.fullUrl(async (resource, options) => {
+      captured = { resource, options }
+      return {}
+    })
+
+    await fetch('/wallets?limit=10', {
+      method: 'GET',
+      apiOptions: { baseUrl: 'https://dfns.example.com/api' },
+    })
+
+    assert.equal(captured.resource.toString(), 'https://dfns.example.com/api/wallets?limit=10')
+    assert.equal(captured.options.userActionHttpPath, '/wallets')
+  })
+
+  it('canonicalizes delegated user-action challenge paths', async () => {
+    let captured
+    fetchModule.simpleFetch = async (resource, options) => {
+      captured = { resource, options }
+      return { json: async () => ({}) }
+    }
+    const { BaseAuthApi } = require('../../../dist/@dfns/sdk/baseAuthApi.js')
+
+    await BaseAuthApi.createUserActionChallenge(
+      {
+        userActionPayload: '{}',
+        userActionHttpMethod: 'POST',
+        userActionHttpPath: '/wallets?archive=false',
+        userActionServerKind: 'Staff',
+      },
+      { baseUrl: 'https://dfns.example.com/api' }
+    )
+
+    assert.equal(captured.resource, '/auth/action/init')
+    assert.equal(captured.options.body.userActionHttpPath, '/wallets')
+    assert.equal(captured.options.body.userActionServerKind, 'Staff')
+  })
+
+  it('rejects ambiguous base URLs', () => {
+    assert.throws(() => buildApiUrl('/wallets', 'https://dfns.example.com/api?tenant=one'))
+    assert.throws(() => buildApiUrl('/wallets', 'https://dfns.example.com/api#fragment'))
+  })
+})

--- a/packages/sdk/utils/url.ts
+++ b/packages/sdk/utils/url.ts
@@ -1,13 +1,44 @@
+const URL_RESOLUTION_BASE = 'https://dfns.invalid'
+
+export const getCanonicalPath = (resource: string | URL): string => {
+  return resource instanceof URL ? resource.pathname : new URL(resource, URL_RESOLUTION_BASE).pathname
+}
+
+export const buildApiUrl = (resource: string | URL, baseUrl: string): URL => {
+  const base = new URL(baseUrl)
+
+  if (base.search || base.hash) {
+    throw new Error('baseUrl must not contain a query string or fragment')
+  }
+
+  if (resource instanceof URL) {
+    return new URL(resource)
+  }
+
+  const resolvedResource = new URL(resource, URL_RESOLUTION_BASE)
+  if (resolvedResource.origin !== URL_RESOLUTION_BASE) {
+    return resolvedResource
+  }
+
+  const basePath = base.pathname.replace(/\/+$/, '')
+  const resourcePath = resolvedResource.pathname.replace(/^\/+/, '')
+  base.pathname = `${basePath}/${resourcePath}`
+  base.search = resolvedResource.search
+  base.hash = resolvedResource.hash
+
+  return base
+}
+
 export const buildPathAndQuery = (
   pattern: string,
-  params: { path: Record<string, any>; query: Record<string, string | number | boolean | string[] | undefined> }
+  params: { path: Record<string, unknown>; query: Record<string, string | number | boolean | string[] | undefined> }
 ): string => {
   let path = pattern
 
   const paramsToReplace = (path.match(new RegExp(`:[a-zA-Z]+`, 'g')) || []).map((v) => v.replace(/^:/, ''))
 
   for (const key of paramsToReplace) {
-    path = path.replace(new RegExp(`:${key}`, 'g'), encodeURIComponent(params.path[key]))
+    path = path.replace(new RegExp(`:${key}`, 'g'), encodeURIComponent(String(params.path[key])))
   }
 
   const query = Object.entries(params.query)

--- a/packages/sdk/utils/userActionFetch.ts
+++ b/packages/sdk/utils/userActionFetch.ts
@@ -10,7 +10,7 @@ const userAction = <T extends DfnsApiClientOptions>(fetch: Fetch<T>): Fetch<T> =
     if (options.method !== 'GET') {
       const apiOptions = {
         ...options.apiOptions,
-        baseUrl: (<any>options.apiOptions).baseAuthUrl || options.apiOptions.baseUrl,
+        baseUrl: options.apiOptions.baseAuthUrl || options.apiOptions.baseUrl,
       }
 
       if (!apiOptions.signer) {
@@ -33,8 +33,8 @@ const userAction = <T extends DfnsApiClientOptions>(fetch: Fetch<T>): Fetch<T> =
         {
           userActionPayload: body,
           userActionHttpMethod: options.method,
-          userActionHttpPath: (<URL>resource).pathname,
-          userActionServerKind: (<any>apiOptions)?.userActionServerKind || 'Api',
+          userActionHttpPath: options.userActionHttpPath ?? (<URL>resource).pathname,
+          userActionServerKind: apiOptions.userActionServerKind ?? 'Api',
         },
         apiOptions
       )


### PR DESCRIPTION
## Summary
- preserve deployment path prefixes when composing SDK transport URLs while keeping existing root URL behavior
- keep deployment prefixes and query strings out of canonical user-action signing paths, including delegated challenges
- default user-action server routing to `Api` while allowing an unadvertised string override for internal staff tooling
- type `baseAuthUrl` and add compiled-runtime regression coverage

## Verification
- `npm run test:sdk` (7 tests)
- `NX_DAEMON=false npm run cb:all` (33 packages)
- ESLint on all changed SDK source and test files
- Prettier and `git diff --check`