### PR TITLE
docs(examples): Solana durable-nonce Sign & Broadcast example (DOC-152)

### DIFF
--- a/examples/libs/solana/durable-nonce-sign-and-broadcast/.env.example
+++ b/examples/libs/solana/durable-nonce-sign-and-broadcast/.env.example
@@ -1,0 +1,9 @@
+DFNS_API_URL='https://api.dfns.io'
+DFNS_ORG_ID='or-xxxxx-xxxxx-xxxxxxxxxxxxxxxx'
+DFNS_CRED_ID='<your service account signing key cred ID>'
+DFNS_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----
+<your service account private key>
+-----END PRIVATE KEY-----'
+DFNS_AUTH_TOKEN='<your service account auth token, starts with eyJ0...>'
+
+SOLANA_WALLET_ID='wa-xxxxx-xxxxx-xxxxxxxxxxxxxxxx'

--- a/examples/libs/solana/durable-nonce-sign-and-broadcast/README.md
+++ b/examples/libs/solana/durable-nonce-sign-and-broadcast/README.md
@@ -1,0 +1,48 @@
+# Solana durable nonce with Sign & Broadcast
+
+Demonstrates the full lifecycle of a self-managed Solana [durable nonce](https://solana.com/developers/guides/advanced/introduction-to-durable-nonces) driven entirely through the DFNS **Sign & Broadcast** API (`wallets.broadcastTransaction`), end to end:
+
+1. **Create** a nonce account owned by your wallet.
+2. **Use** it several times: build a durable-nonce transaction, sign & broadcast it, wait for confirmation, repeat.
+3. **Destroy** it by withdrawing its balance, which closes the account and reclaims the rent.
+
+A durable nonce replaces the recent blockhash in a transaction, so the signed transaction never expires. This is what lets an asynchronous step — a policy approval, or an offline signer — sit between building the transaction and broadcasting it without the transaction going stale.
+
+The transaction is built client-side with [`@solana/web3.js`](https://solana.com/docs/clients/javascript) and submitted unsigned (with zero-padded placeholder signatures); DFNS produces the signature during the MPC signing ceremony and broadcasts it.
+
+## Self-managed vs. the DFNS nonce pool
+
+This example manages the nonce account itself. If you only need durable nonces for **SOL and SPL transfers**, prefer the DFNS-managed pool instead: bootstrap it once with the `CreateSolanaNonceAccounts` transaction kind, then set `useDurableNonce: true` on your transfers and DFNS picks and advances a nonce for you. See [Use Solana durable nonces](https://docs.dfns.co/guides/solana-durable-nonces).
+
+Use the self-managed flow shown here when you need a durable nonce on an **arbitrary** transaction you build yourself and send through Sign & Broadcast. Keep your seed distinct from the pool's `nonce/<index>` seeds (this example uses `my-app/nonce/0`) so the two never collide, and don't manually use a pool account, or DFNS's reservation tracking and your transaction can pick the same nonce.
+
+## Prerequisites
+
+You need a `Service Account`: refer to the [developer guide](https://docs.dfns.co/guides/developers/service-account).
+
+Copy `.env.example` to a new file `.env` and set the following values:
+
+- `DFNS_API_URL` = `https://api.dfns.io`
+- `DFNS_ORG_ID` = DFNS organization ID (see how to [find your organization ID](https://docs.dfns.co/guides/find-organization-id))
+- `DFNS_CRED_ID` = the `Signing Key Cred ID` of your service account
+- `DFNS_PRIVATE_KEY` = the private key of your service account
+- `DFNS_AUTH_TOKEN` = the auth token of your service account (starts with `eyJ0...`)
+- `SOLANA_WALLET_ID` = a DFNS Solana [wallet](https://docs.dfns.co/api-reference/wallets) ID
+
+**Note:** the Solana wallet must hold devnet SOL to fund the nonce account rent and pay fees.
+
+## Run
+
+```shell
+> ts-node main.ts
+
+Solana wallet:  D1FRN8fYGKsrEj5ZtsHDbksZ6xFbmsDeUNYBn8Xn46nT
+Nonce account:  8r2JtxqNeMX1ZvpK66tL3skFa5DV3DdnsMCufNh1rcEJ
+Create nonce account: request tx-xxxxx-xxxxx-xxxxxxxxxxxxxxxx submitted, waiting for confirmation…
+Create nonce account: confirmed — 51Xzfo…KTJvB
+Durable-nonce transfer 1: request tx-… submitted, waiting for confirmation…
+Durable-nonce transfer 1: confirmed — 3vN2…9kQd
+...
+Destroy nonce account: confirmed — 2pLm…Rt7x
+Done.
+```

--- a/examples/libs/solana/durable-nonce-sign-and-broadcast/main.ts
+++ b/examples/libs/solana/durable-nonce-sign-and-broadcast/main.ts
@@ -1,0 +1,145 @@
+import { DfnsApiClient } from '@dfns/sdk'
+import { AsymmetricKeySigner } from '@dfns/sdk-keysigner'
+import {
+  clusterApiUrl,
+  Connection,
+  NONCE_ACCOUNT_LENGTH,
+  NonceAccount,
+  PublicKey,
+  SystemProgram,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const dfnsClient = new DfnsApiClient({
+  orgId: process.env.DFNS_ORG_ID!,
+  authToken: process.env.DFNS_AUTH_TOKEN!,
+  baseUrl: process.env.DFNS_API_URL!,
+  signer: new AsymmetricKeySigner({
+    credId: process.env.DFNS_CRED_ID!,
+    privateKey: process.env.DFNS_PRIVATE_KEY!,
+  }),
+})
+
+const walletId = process.env.SOLANA_WALLET_ID!
+const connection = new Connection(clusterApiUrl('devnet'), 'confirmed')
+
+// A seed you control, used to derive the nonce account address from the wallet. Keep it distinct
+// from the `nonce/<index>` seeds DFNS uses for its server-managed pool (the CreateSolanaNonceAccounts
+// transaction kind), so a self-managed account and a pool account can never collide.
+const NONCE_SEED = 'my-app/nonce/0'
+
+// DFNS Sign & Broadcast expects an unsigned, hex-encoded transaction. A freshly built
+// VersionedTransaction already carries zero-padded placeholder signatures, which is exactly what the
+// endpoint needs — DFNS fills in the real signature during the MPC signing ceremony.
+const toDfnsHex = (tx: VersionedTransaction) => `0x${Buffer.from(tx.serialize()).toString('hex')}`
+
+// Submit an unsigned transaction to DFNS Sign & Broadcast, then poll the transaction request until it
+// is confirmed on-chain. Confirmation matters here: a durable nonce only advances once its transaction
+// executes, so each reuse must wait for the previous one to confirm.
+const signBroadcastAndWait = async (tx: VersionedTransaction, label: string): Promise<void> => {
+  const { id } = await dfnsClient.wallets.broadcastTransaction({
+    walletId,
+    body: { kind: 'Transaction', transaction: toDfnsHex(tx) },
+  })
+  console.log(`${label}: request ${id} submitted, waiting for confirmation…`)
+
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const request = await dfnsClient.wallets.getTransaction({ walletId, transactionId: id })
+    if (request.status === 'Confirmed') {
+      console.log(`${label}: confirmed — ${request.txHash}`)
+      return
+    }
+    if (request.status === 'Failed' || request.status === 'Rejected') {
+      throw new Error(`${label}: transaction ${request.status}`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+  }
+  throw new Error(`${label}: timed out waiting for confirmation`)
+}
+
+const main = async () => {
+  const wallet = await dfnsClient.wallets.getWallet({ walletId })
+  const walletPubkey = new PublicKey(wallet.address)
+  const noncePubkey = await PublicKey.createWithSeed(walletPubkey, NONCE_SEED, SystemProgram.programId)
+  console.log(`Solana wallet:  ${wallet.address}`)
+  console.log(`Nonce account:  ${noncePubkey.toBase58()}`)
+
+  // 1. Create the nonce account (once). createAccountWithSeed derives the account address from the
+  //    wallet, so the wallet is the only required signer — there is no extra keypair for DFNS to sign
+  //    for. This bootstrap transaction is ordinary, so it uses a recent blockhash.
+  if (!(await connection.getAccountInfo(noncePubkey))) {
+    const rentExemption = await connection.getMinimumBalanceForRentExemption(NONCE_ACCOUNT_LENGTH)
+    const { blockhash } = await connection.getLatestBlockhash()
+    const createTx = new VersionedTransaction(
+      new TransactionMessage({
+        payerKey: walletPubkey,
+        recentBlockhash: blockhash,
+        instructions: [
+          SystemProgram.createAccountWithSeed({
+            fromPubkey: walletPubkey,
+            newAccountPubkey: noncePubkey,
+            basePubkey: walletPubkey,
+            seed: NONCE_SEED,
+            lamports: rentExemption,
+            space: NONCE_ACCOUNT_LENGTH,
+            programId: SystemProgram.programId,
+          }),
+          SystemProgram.nonceInitialize({ noncePubkey, authorizedPubkey: walletPubkey }),
+        ],
+      }).compileToV0Message()
+    )
+    await signBroadcastAndWait(createTx, 'Create nonce account')
+  } else {
+    console.log('Nonce account already exists, reusing it')
+  }
+
+  // 2. Use the durable nonce several times. Re-read the nonce value before each transaction: every
+  //    executed durable-nonce transaction advances the stored nonce to a new value, so a stale value
+  //    would be rejected.
+  const recipient = new PublicKey('3U6stgsD1FmA7o3omUguritCU8iWmUM7Rs6KqAHHxHVZ')
+  for (let i = 1; i <= 3; i++) {
+    const info = await connection.getAccountInfo(noncePubkey)
+    if (!info) throw new Error('nonce account not found')
+    const { nonce } = NonceAccount.fromAccountData(info.data)
+
+    const tx = new VersionedTransaction(
+      new TransactionMessage({
+        payerKey: walletPubkey,
+        recentBlockhash: nonce, // the durable nonce takes the place of a recent blockhash
+        instructions: [
+          // AdvanceNonceAccount MUST be the first instruction of a durable-nonce transaction.
+          SystemProgram.nonceAdvance({ noncePubkey, authorizedPubkey: walletPubkey }),
+          SystemProgram.transfer({ fromPubkey: walletPubkey, toPubkey: recipient, lamports: 1 }),
+        ],
+      }).compileToV0Message()
+    )
+    await signBroadcastAndWait(tx, `Durable-nonce transfer ${i}`)
+  }
+
+  // 3. Destroy the nonce account by withdrawing its full balance, which closes it. This reclaims the
+  //    rent-exempt deposit. The withdrawal is an ordinary transaction, so it uses a recent blockhash.
+  const balance = await connection.getBalance(noncePubkey)
+  const { blockhash } = await connection.getLatestBlockhash()
+  const closeTx = new VersionedTransaction(
+    new TransactionMessage({
+      payerKey: walletPubkey,
+      recentBlockhash: blockhash,
+      instructions: [
+        SystemProgram.nonceWithdraw({
+          noncePubkey,
+          authorizedPubkey: walletPubkey,
+          toPubkey: walletPubkey,
+          lamports: balance,
+        }),
+      ],
+    }).compileToV0Message()
+  )
+  await signBroadcastAndWait(closeTx, 'Destroy nonce account')
+  console.log('Done.')
+}
+
+main()

--- a/examples/libs/solana/durable-nonce-sign-and-broadcast/package.json
+++ b/examples/libs/solana/durable-nonce-sign-and-broadcast/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "solana-durable-nonce-sign-and-broadcast",
+  "version": "1.0.0",
+  "main": "main.ts",
+  "dependencies": {
+    "@dfns/sdk": "file:../../../packages/sdk",
+    "@dfns/sdk-keysigner": "file:../../../packages/sdk-keysigner",
+    "@solana/web3.js": "^1.87.6",
+    "dotenv": "16.1.4"
+  },
+  "devDependencies": {
+    "ts-node": "10.9.1"
+  },
+  "scripts": {
+    "exec": "ts-node main.ts"
+  }
+}


### PR DESCRIPTION
## What

Adds `examples/libs/solana/durable-nonce-sign-and-broadcast/` — the end-to-end lifecycle of a self-managed Solana durable nonce driven entirely through the DFNS **Sign & Broadcast** API (`wallets.broadcastTransaction`, `kind: "Transaction"`), as requested in DOC-152:

1. **Create** a nonce account owned by the wallet — `createAccountWithSeed` + `nonceInitialize`, so the wallet is the only required signer (no ephemeral keypair for DFNS to sign for).
2. **Use** it several times — build a durable-nonce transaction (`nonceAdvance` as the first instruction, the nonce value in place of a recent blockhash), sign & broadcast, wait for on-chain confirmation, then re-read the advanced nonce before the next one.
3. **Destroy** it — `nonceWithdraw` of the full balance closes the account and reclaims the rent.

Transactions are built unsigned with `@solana/web3.js` and submitted as hex with zero-padded placeholder signatures; DFNS produces the real signature via MPC and broadcasts.

## Why a new example (vs `durable-nonce-tx`)

The existing `durable-nonce-tx` example signs with `@dfns/lib-solana` and **self-broadcasts** via `connection.sendRawTransaction`. This one uses the DFNS Sign & Broadcast endpoint instead, and adds the create + destroy steps. The README explains when to use this self-managed flow vs the DFNS-managed pool (`CreateSolanaNonceAccounts` + `useDurableNonce`, which is the recommended path for plain SOL/SPL transfers), and warns to keep the seed distinct from the pool's `nonce/<index>` seeds.

## Verification

- API surface verified against the installed `@solana/web3.js` (v1.98.4, satisfies `^1.87.6`): `createAccountWithSeed`, `nonceInitialize`, `nonceAdvance`, `nonceWithdraw`, `NonceAccount.fromAccountData`, `PublicKey.createWithSeed`.
- DFNS SDK calls verified against the generated client/types: `wallets.getWallet`, `wallets.broadcastTransaction` (`{ kind: 'Transaction', transaction }`), `wallets.getTransaction` (status `Pending|Executing|Broadcasted|Confirmed|Failed|Rejected`, `txHash`).
- Prettier-clean against the repo config.
- Construction logic mirrors the tested `durable-nonce-tx` example. Like every example here it needs live service-account credentials + a devnet wallet to run end-to-end, so it is not executed in CI.

For DOC-152. Paired with a dfns-docs PR that links this example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)