### PR TITLE
fix(lib-concordium): pin @concordium/web-sdk peer to 12.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aptos-labs/ts-sdk": "^5.0.0",
         "@aws-sdk/client-kms": "^3.1027.0",
         "@concordium/id-app-sdk": "0.1.4",
-        "@concordium/web-sdk": "12.0.0-alpha.3",
+        "@concordium/web-sdk": "12.0.2",
         "@dfns/dfns-key-export-bundler": "0.4.0",
         "@dfns/dfns-key-export-nodejs": "0.4.0",
         "@dfns/dfns-key-import-bundler": "0.4.0",
@@ -3124,12 +3124,12 @@
       }
     },
     "node_modules/@concordium/web-sdk": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@concordium/web-sdk/-/web-sdk-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-o0gXac3/LtvjYFnGpogpDKKAfG7x9P0EZdD1jLnTkkGNHvfqrJlrtcI08Aii1O4E+sF7e6pivkAS/3pqZvJXkQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@concordium/web-sdk/-/web-sdk-12.0.2.tgz",
+      "integrity": "sha512-GyB4WQQKnNq/VOCQaVbLBHPFoszvU17Klqj5mbpGkvrdSDvny5J/VosWtr2LHAHo7OrDRBDzRtAobuzglay86Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@concordium/rust-bindings": "^3.3.0",
+        "@concordium/rust-bindings": "^4.0.1",
         "@grpc/grpc-js": "^1.14.0",
         "@noble/ed25519": "^2.0.0",
         "@noble/hashes": "^1.3.2",
@@ -3153,6 +3153,15 @@
       "peerDependencies": {
         "@protobuf-ts/runtime-rpc": "^2.8.2",
         "cbor2": "^1.12.0"
+      }
+    },
+    "node_modules/@concordium/web-sdk/node_modules/@concordium/rust-bindings": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@concordium/rust-bindings/-/rust-bindings-4.0.1.tgz",
+      "integrity": "sha512-poJUD5qFh57wenTUKP93gL4YLSzsfnznniRgEY7OaUwa2drkLyAw+SQO0Ou7THwz8elT7pXB4bLKvIm+J+4RpA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@concordium/web-sdk/node_modules/uuid": {
@@ -17813,7 +17822,7 @@
       "name": "@dfns/lib-concordium",
       "version": "0.8.29",
       "peerDependencies": {
-        "@concordium/web-sdk": "12.0.0-alpha.3"
+        "@concordium/web-sdk": "12.0.2"
       }
     },
     "packages/lib-cosmjs": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@aptos-labs/ts-sdk": "^5.0.0",
     "@aws-sdk/client-kms": "^3.1027.0",
     "@concordium/id-app-sdk": "0.1.4",
-    "@concordium/web-sdk": "12.0.0-alpha.3",
+    "@concordium/web-sdk": "12.0.2",
     "@dfns/dfns-key-export-bundler": "0.4.0",
     "@dfns/dfns-key-export-nodejs": "0.4.0",
     "@dfns/dfns-key-import-bundler": "0.4.0",

--- a/packages/lib-concordium/package.json
+++ b/packages/lib-concordium/package.json
@@ -7,6 +7,6 @@
     "directory": "packages/lib-concordium"
   },
   "peerDependencies": {
-    "@concordium/web-sdk": "12.0.0-alpha.3"
+    "@concordium/web-sdk": "12.0.2"
   }
 }


### PR DESCRIPTION
The `@concordium/web-sdk` peer in `packages/lib-concordium` was pinned to the exact prerelease `12.0.0-alpha.3`. Any workspace bump of `@concordium/web-sdk` past that version therefore failed `npm install` with `ERESOLVE` — which is what blocked the grouped Dependabot PR #713 (it tries to move the root to `12.0.2`).

## Change
- `packages/lib-concordium`: widen the peer from `12.0.0-alpha.3` → `>=12.0.0-alpha.3 <13.0.0` (still accepts the old prerelease, now also the stable 12.x line).
- root `package.json`: adopt `@concordium/web-sdk@12.0.2` in the dev harness (which resolves against the workspace `lib-concordium`), regenerating the lockfile.

## Verification
`npm ci` + `npm run cb:all` (the `build`/`compile` job) on Node 24 in a clean container: install resolves with no `ERESOLVE`, and all 33 workspace projects compile — `lib-concordium` builds unchanged against `12.0.2` (it only uses the stable `AccountAddress` / `Transaction` APIs).

## Scope
web-sdk only. The example manifests still consume the *published* `@dfns/lib-concordium` (which peers the old `alpha.3` until this ships in the next release), so their web-sdk pins are intentionally left at `alpha.3` for now. Once a release publishes the widened peer, #713 can rebase (its `@concordium/web-sdk` bump becomes a no-op) and merge.